### PR TITLE
API Service class setup for app

### DIFF
--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -76,7 +76,6 @@ class _HomeScreenState extends State<HomeScreen> {
       final response = await apiService.searchArtwork(query);
       return response.data.toString();
     } catch (e) {
-      print("Error: $e");
       throw Exception("Failed to fetch artwork");
     }
   }

--- a/lib/ui/widgets/api_service.dart
+++ b/lib/ui/widgets/api_service.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+
+class APIService {
+  final dio = Dio();
+  final String baseUrl = "http://localhost:8000/";
+
+  Future<Response> searchArtwork(String query) async {
+    try {
+      Response response;
+      response = await dio.get("${baseUrl}smk/search-artwork", queryParameters: {"keys": query});
+      return response;
+    } catch (e) {
+      throw Exception("Failed to fetch artwork");
+    }
+  }
+
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.0+1"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   flutter_map: ^8.0.0
   location: ^8.0.0
   latlong2: ^0.9.1
+  dio: ^5.8.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request introduces a new API service to fetch artwork data and integrates it into the `HomeScreen` component. The most important changes include adding the `dio` dependency, creating the `APIService` class, and updating the `HomeScreen` to use the new service.

### Integration of new API service:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R20): Added `dio` dependency to handle HTTP requests.
* [`lib/ui/widgets/api_service.dart`](diffhunk://#diff-4b6acc0a532010100e214528b4961d80cba9875172f6d8c985cfa9ca8c3b0bf2R1-R17): Created `APIService` class with a method to fetch artwork data from the API.

### Updates to `HomeScreen`:

* [`lib/ui/screens/home_screen.dart`](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2L9-R9): Imported the new `APIService` class.
* [`lib/ui/screens/home_screen.dart`](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R31): Instantiated the `APIService` class in the `_HomeScreenState`.
* [`lib/ui/screens/home_screen.dart`](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R74-R83): Added `fetchArtwork` method to `_HomeScreenState` to fetch artwork data using the `APIService`.
* [`lib/ui/screens/home_screen.dart`](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2L127-R154): Updated the room dialog to use a `FutureBuilder` to display artwork data.