### PR TITLE
[Frontend]: Exhibits button/search 🎨 🔍 

### DIFF
--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -71,15 +71,6 @@ class _HomeScreenState extends State<HomeScreen> {
     Navigator.pop(context);
   }
 
-  Future<String> fetchArtwork(String query) async {
-    try {
-      final response = await apiService.searchArtwork(query);
-      return response.data.toString();
-    } catch (e) {
-      throw Exception("Failed to fetch artwork");
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     final List<EdgeSegment> segments = createEdgeSegments(_edges, _nodeMap);
@@ -134,23 +125,7 @@ class _HomeScreenState extends State<HomeScreen> {
                           context: context,
                           builder: (context) => AlertDialog(
                             title: Text(room.name),
-                            content: FutureBuilder<String>(
-                              future: fetchArtwork("minimumsbetragtning"), 
-                              builder: (context, snapshot) {
-                                if (snapshot.connectionState == ConnectionState.waiting) {
-                                  return const Center(child: CircularProgressIndicator());
-                                } else if (snapshot.hasError) {
-                                  return Text("Error: ${snapshot.error}");
-                                } else {
-                                  return Card(
-                                    child: Padding(
-                                      padding: const EdgeInsets.all(8.0),
-                                      child: Text(snapshot.data ?? "No data available"),
-                                    ),
-                                  );
-                                }
-                              },
-                            ),
+                            content: Text(room.description),
                             actions: [
                               TextButton(
                                 onPressed: () => Navigator.pop(context),

--- a/lib/ui/widgets/api_service.dart
+++ b/lib/ui/widgets/api_service.dart
@@ -14,4 +14,14 @@ class APIService {
     }
   }
 
+  Future<Response> getArtwork(String query) async {
+    try {
+      Response response;
+      response = await dio.get("${baseUrl}smk/get-artwork", queryParameters: {"keys": query});
+      return response;
+    } catch (e) {
+      throw Exception("Failed to fetch artwork");
+    }
+  }
+
 }

--- a/lib/ui/widgets/burger_drawer.dart
+++ b/lib/ui/widgets/burger_drawer.dart
@@ -1,9 +1,22 @@
 import 'package:flutter/material.dart';
+import 'exhibits_menu.dart';
 
-class BurgerDrawer extends StatelessWidget {
+class BurgerDrawer extends StatefulWidget {
   final void Function(String category) highlightedCategory;
 
   const BurgerDrawer({super.key, required this.highlightedCategory});
+
+  @override
+  State<BurgerDrawer> createState() => BurgerDrawerState();
+}
+
+class BurgerDrawerState extends State<BurgerDrawer> {
+
+  bool showExhibitsMenu = false;
+
+  void highlightedCategory(String category) {
+    widget.highlightedCategory(category);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -12,7 +25,8 @@ class BurgerDrawer extends StatelessWidget {
         children: [
           Expanded(
             child: Center(
-              child: ListView(
+              child: showExhibitsMenu ? const ExhibitsMenu() :
+              ListView(
                 shrinkWrap: true,
                 children: <Widget>[
                   ListTile(
@@ -29,9 +43,12 @@ class BurgerDrawer extends StatelessWidget {
                     title: const Text('Food'),
                     onTap: () => highlightedCategory("Cafeteria"),
                   ),
-                  const ListTile(
-                    leading: Icon(Icons.location_on_outlined),
-                    title: Text('Highlights'),
+                  ListTile(
+                    leading: const Icon(Icons.location_on_outlined),
+                    title: const Text('Exhibits'),
+                    onTap: () => setState(() {
+                      showExhibitsMenu = true;
+                    }),
                   ),
                   const ListTile(
                     leading: Icon(Icons.web),

--- a/lib/ui/widgets/burger_drawer.dart
+++ b/lib/ui/widgets/burger_drawer.dart
@@ -20,7 +20,6 @@ class BurgerDrawerState extends State<BurgerDrawer> {
     setState(() {
       showExhibitsMenu = show;
     });
-    print(showExhibitsMenu);
   }
 
   @override

--- a/lib/ui/widgets/burger_drawer.dart
+++ b/lib/ui/widgets/burger_drawer.dart
@@ -3,19 +3,24 @@ import 'exhibits_menu.dart';
 
 class BurgerDrawer extends StatefulWidget {
   final void Function(String category) highlightedCategory;
-
-  const BurgerDrawer({super.key, required this.highlightedCategory});
-
+  const BurgerDrawer({super.key, this.highlightedCategory = _defaultHighlightedCategory});
+  static void _defaultHighlightedCategory(String category) {}
   @override
   State<BurgerDrawer> createState() => BurgerDrawerState();
 }
 
 class BurgerDrawerState extends State<BurgerDrawer> {
-
   bool showExhibitsMenu = false;
 
   void highlightedCategory(String category) {
     widget.highlightedCategory(category);
+  }
+
+  void showExhibitsMenuFunc(bool show) {
+    setState(() {
+      showExhibitsMenu = show;
+    });
+    print(showExhibitsMenu);
   }
 
   @override
@@ -25,7 +30,7 @@ class BurgerDrawerState extends State<BurgerDrawer> {
         children: [
           Expanded(
             child: Center(
-              child: showExhibitsMenu ? const ExhibitsMenu() :
+              child: showExhibitsMenu ? ExhibitsMenu(showExhibitsMenu: showExhibitsMenuFunc) :
               ListView(
                 shrinkWrap: true,
                 children: <Widget>[

--- a/lib/ui/widgets/exhibits_menu.dart
+++ b/lib/ui/widgets/exhibits_menu.dart
@@ -79,7 +79,10 @@ class _ExhibitsMenuState extends State<ExhibitsMenu> {
                         return FutureBuilder(
                           future: apiService.getArtwork(artworks[index]),
                           builder: (context, snapshot) {
-                            if (snapshot.hasError) {
+                            if (snapshot.connectionState == ConnectionState.waiting) {
+                              return const Center(child: Text(""));
+                            }
+                            else if (snapshot.hasError) {
                               return const Center(child: Text("Error loading artwork"));
                             } else {
                               final artwork = snapshot.data?.data[0];

--- a/lib/ui/widgets/exhibits_menu.dart
+++ b/lib/ui/widgets/exhibits_menu.dart
@@ -79,14 +79,9 @@ class _ExhibitsMenuState extends State<ExhibitsMenu> {
                         return FutureBuilder(
                           future: apiService.getArtwork(artworks[index]),
                           builder: (context, snapshot) {
-                            if (snapshot.connectionState == ConnectionState.waiting) {
-                              fetchingArtworks = true;
-                              return const Center(child: Text(""));
-                            } else if (snapshot.hasError) {
-                              fetchingArtworks = false;
+                            if (snapshot.hasError) {
                               return const Center(child: Text("Error loading artwork"));
                             } else {
-                              fetchingArtworks = false;
                               final artwork = snapshot.data?.data[0];
                               return Card(
                                 child: ListTile(
@@ -99,15 +94,6 @@ class _ExhibitsMenuState extends State<ExhibitsMenu> {
                         );
                       },
                     ),
-                    if (fetchingArtworks)
-                      Positioned.fill(
-                        child: Container(
-                          color: Colors.black.withOpacity(0.3),
-                          child: const Center(
-                            child: CircularProgressIndicator(),
-                          ),
-                        ),
-                      ),
                   ])
               ),
             ],

--- a/lib/ui/widgets/exhibits_menu.dart
+++ b/lib/ui/widgets/exhibits_menu.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'api_service.dart';
+
+class ExhibitsMenu extends StatefulWidget {
+  const ExhibitsMenu({super.key});
+
+  @override
+  State<ExhibitsMenu> createState() => _ExhibitsMenuState();
+}
+
+class _ExhibitsMenuState extends State<ExhibitsMenu> {
+  APIService apiService = APIService();
+  List<String> previousSearch = [];
+  List<String> artworks = [];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        body: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            children: <Widget>[
+              SearchAnchor(
+                builder: (BuildContext context, SearchController controller) {
+                  return SearchBar(
+                    controller: controller,
+                    padding: const WidgetStatePropertyAll<EdgeInsets>(
+                      EdgeInsets.symmetric(horizontal: 16.0),
+                    ),
+                    onSubmitted: (query) async {
+                      try {
+                        final response = await apiService.searchArtwork(query);
+                        final List<dynamic> data = response.data;
+                        setState(() {
+                          artworks = List<String>.from(data);
+                          print(artworks[0] is String);
+                        });
+                      } catch (e) {
+                        print("Error fetching artwork: $e");
+                      }
+                    },
+                    leading: const Icon(Icons.search),
+                  );
+                },
+                suggestionsBuilder: (BuildContext context, SearchController controller) {
+                  return List<ListTile>.generate(previousSearch.length > 5 ? 5 : previousSearch.length, (int index) {
+                    final String item = previousSearch[index];
+                    return ListTile(
+                      title: Text(item),
+                      onTap: () {
+                        setState(() {
+                          controller.closeView(item);
+                        });
+                      },
+                    );
+                  });
+                },
+              ),
+              Expanded(
+                child: artworks.isEmpty ? const Center(child: Text("No results found"))
+                  : ListView.builder(
+                      itemCount: artworks.length,
+                      itemBuilder: (context, index) {
+                        return FutureBuilder(
+                          future: apiService.getArtwork(artworks[index]),
+                          builder: (context, snapshot) {
+                            if (snapshot.connectionState == ConnectionState.waiting) {
+                              return const Center(child: CircularProgressIndicator());
+                            } else if (snapshot.hasError) {
+                              return const Center(child: Text("Error loading artwork"));
+                            } else {
+                              final artwork = snapshot.data?.data[0];
+                              return Card(
+                                child: ListTile(
+                                  title: Text("Room: ${artwork["room"] ?? "Not on display"}"),
+                                  subtitle: Text("Artwork ID: ${artwork["id"]}"),
+                                ),
+                              );
+                            }
+                          },
+                        );
+                      },
+                    ),
+              ),
+            ],
+          ),
+        ),
+    );
+  }
+}

--- a/lib/ui/widgets/exhibits_menu.dart
+++ b/lib/ui/widgets/exhibits_menu.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'api_service.dart';
-import 'burger_drawer.dart';
 
 class ExhibitsMenu extends StatefulWidget {
   final void Function(bool show) showExhibitsMenu;
@@ -49,7 +48,7 @@ class _ExhibitsMenuState extends State<ExhibitsMenu> {
                           artworks = List<String>.from(data);
                         });
                       } catch (e) {
-                        print("Error fetching artwork: $e");
+                        throw Exception("Failed to search for artworks");
                       }
                     },
                     leading: const Icon(Icons.search),

--- a/test/burger_menu_tests/burger_menu_test.dart
+++ b/test/burger_menu_tests/burger_menu_test.dart
@@ -51,7 +51,7 @@ void main() {
     expect(isExhibitsMenuVisible, false);
   });
 
-  testWidgets('onSubmitted function is triggered when text is submitted', (WidgetTester tester) async {
+  testWidgets('Text field is able to be altered', (WidgetTester tester) async {
     // Build the widget tree
     await tester.pumpWidget(const MaterialApp(home: ExhibitsMenu()));
     // Find the search bar
@@ -59,9 +59,6 @@ void main() {
     expect(textField, findsOneWidget);
     // Enter text into the search bar
     await tester.enterText(textField, "Mona Lisa");
-
-    // Simulate the "submit" action (like pressing "Enter" on a keyboard)
-    await tester.testTextInput.receiveAction(TextInputAction.done);
-    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.text("Mona Lisa"), findsOneWidget);
   });
 }

--- a/test/burger_menu_tests/burger_menu_test.dart
+++ b/test/burger_menu_tests/burger_menu_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:indoor_crowded_regions_frontend/my_app.dart';
 import 'package:flutter_map/flutter_map.dart';
-
+import 'package:indoor_crowded_regions_frontend/ui/widgets/exhibits_menu.dart';
 import 'package:indoor_crowded_regions_frontend/ui/widgets/burger_menu.dart';
 
 void main() {
@@ -25,5 +25,43 @@ void main() {
     expect(find.text('Bathrooms'), findsOneWidget);
 
     await tester.pumpAndSettle();
+  });
+
+  testWidgets('Exhibits menu closes when back button is tapped', (WidgetTester tester) async {
+    bool isExhibitsMenuVisible = true;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ExhibitsMenu(
+          showExhibitsMenu: (show) {
+            isExhibitsMenuVisible = show;
+          },
+        ),
+      ),
+    );
+
+    // Ensure the exhibits menu is displayed initially
+    expect(find.text("Search Exhibits"), findsOneWidget);
+    expect(find.byType(SearchBar), findsOneWidget);
+    // Tap the back button
+    await tester.tap(find.byIcon(Icons.chevron_left));
+    await tester.pump();
+
+    // Verify the callback updates the state correctly
+    expect(isExhibitsMenuVisible, false);
+  });
+
+  testWidgets('onSubmitted function is triggered when text is submitted', (WidgetTester tester) async {
+    // Build the widget tree
+    await tester.pumpWidget(const MaterialApp(home: ExhibitsMenu()));
+    // Find the search bar
+    final textField = find.byType(TextField);
+    expect(textField, findsOneWidget);
+    // Enter text into the search bar
+    await tester.enterText(textField, "Mona Lisa");
+
+    // Simulate the "submit" action (like pressing "Enter" on a keyboard)
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump(const Duration(milliseconds: 200));
   });
 }


### PR DESCRIPTION
This pull request includes several changes to the `lib/ui/screens/home_screen.dart`, `lib/ui/widgets/api_service.dart`, `lib/ui/widgets/burger_drawer.dart`, and `lib/ui/widgets/exhibits_menu.dart` files to enhance the functionality of the exhibits menu and improve code maintainability. The most important changes include the removal of the `fetchArtwork` method, the addition of a new `getArtwork` method, the conversion of `BurgerDrawer` from a stateless to a stateful widget, and the creation of a new `ExhibitsMenu` widget.

### Codebase improvements:

* [`lib/ui/screens/home_screen.dart`](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2L74-L82): Removed the `fetchArtwork` method and replaced the `FutureBuilder` in the AlertDialog content with a simple `Text` widget. [[1]](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2L74-L82) [[2]](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2L137-R128)
* [`lib/ui/widgets/api_service.dart`](diffhunk://#diff-4b6acc0a532010100e214528b4961d80cba9875172f6d8c985cfa9ca8c3b0bf2R17-R26): Added a new `getArtwork` method to fetch artwork data from the API.

### New feature implementation:

* [`lib/ui/widgets/burger_drawer.dart`](diffhunk://#diff-6194a6829277f015d12605a1fe79109fcce12e249e8ff3d78398632cdedcd7caR2-R24): Converted `BurgerDrawer` from a stateless to a stateful widget to manage the state of the exhibits menu. Added functionality to show the `ExhibitsMenu` when the "Exhibits" list tile is tapped. [[1]](diffhunk://#diff-6194a6829277f015d12605a1fe79109fcce12e249e8ff3d78398632cdedcd7caR2-R24) [[2]](diffhunk://#diff-6194a6829277f015d12605a1fe79109fcce12e249e8ff3d78398632cdedcd7caL15-R34) [[3]](diffhunk://#diff-6194a6829277f015d12605a1fe79109fcce12e249e8ff3d78398632cdedcd7caL32-R56)
* [`lib/ui/widgets/exhibits_menu.dart`](diffhunk://#diff-ab97f9429ea2e34fbcf07530facd58c8d86279fcf9caa9ccb0a23dfb12d82196R1-R107): Created a new `ExhibitsMenu` widget that includes a search bar to search for exhibits and displays the search results.

### Test updates:

* [`test/burger_menu_tests/burger_menu_test.dart`](diffhunk://#diff-72117d9e8419f998d38a57e64283c1bf4851704d2e7bd0ddc845b2ecac2b0021L5-R5): Added new widget tests to verify the functionality of the `ExhibitsMenu`, including closing the menu when the back button is tapped and triggering the `onSubmitted` function when text is submitted. [[1]](diffhunk://#diff-72117d9e8419f998d38a57e64283c1bf4851704d2e7bd0ddc845b2ecac2b0021L5-R5) [[2]](diffhunk://#diff-72117d9e8419f998d38a57e64283c1bf4851704d2e7bd0ddc845b2ecac2b0021R29-R66)