### PR TITLE
Feat: Room infopanel includes artworks

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -33,4 +33,18 @@ class APIService {
     }
   }
 
+  Future<Response> getArtworksByRoomId(String query, {int rows = 20, int offset = 0}) async {
+    try {
+      Response response;
+      response = await dio.get("/artwork", queryParameters: {
+        "room": query,
+        "rows": rows,
+        "offset": offset,
+      });
+      return response;
+    } catch (e) {
+      ErrorToast.show("Failed to fetch artworks for room");
+      rethrow;
+    }
+  }
 }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -18,32 +18,19 @@ class APIService {
     }
   }
 
-  Future<Response> getArtwork(String query, {int rows = 20, int offset = 0}) async {
+  Future<Response> getArtwork(String query, {int rows = 20, int offset = 0, bool roomIdQuery = false}) async {
     try {
       Response response;
       response = await dio.get("/artwork", queryParameters: {
-        "keys": query,
+        roomIdQuery ? "room" : "keys" : query,
         "rows": rows,
         "offset": offset,
       });
       return response;
     } catch (e) {
-      ErrorToast.show("Failed to fetch artwork");
-      rethrow;
-    }
-  }
-
-  Future<Response> getArtworksByRoomId(String query, {int rows = 20, int offset = 0}) async {
-    try {
-      Response response;
-      response = await dio.get("/artwork", queryParameters: {
-        "room": query,
-        "rows": rows,
-        "offset": offset,
-      });
-      return response;
-    } catch (e) {
-      ErrorToast.show("Failed to fetch artworks for room");
+      roomIdQuery 
+        ? ErrorToast.show("Failed to fetch artworks for room") 
+        : ErrorToast.show("Failed to fetch artwork");
       rethrow;
     }
   }

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -237,7 +237,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       return;
     }
 
-    if (_selectedPolygon!.id == tappedPolygon.id) {
+    if (_selectedPolygon?.id == tappedPolygon.id) {
       setState(() {
         _selectedPolygon = null;
         _showInfoPanel = false;

--- a/lib/ui/widgets/polygon_info_panel.dart
+++ b/lib/ui/widgets/polygon_info_panel.dart
@@ -149,17 +149,14 @@ class PolygonInfoPanel extends StatelessWidget {
                                   itemCount: exhibits.length,
                                   itemBuilder: (context, index) {
                                     final exhibit = exhibits[index];
-
                                     final title = (exhibit['titles'] as List?)?.isNotEmpty == true
                                         ? exhibit['titles'][0]['title'] ?? 'Untitled'
                                         : 'Untitled';
-
                                     final artist = (exhibit['artist'] as List?)?.isNotEmpty == true
-                                        ? exhibit['artist'][0] ?? 'Unknown artist'
-                                        : 'Unknown artist';
-
-                                    final String thumbnail = exhibit['image_thumbnail'];
-                                    final String frontendUrl = exhibit['frontend_url'];
+                                        ? exhibit['artist'][0] ?? 'Unknown'
+                                        : 'Unknown';
+                                    final String? thumbnail = exhibit['image_thumbnail'];
+                                    final String? frontendUrl = exhibit['frontend_url'];
                                     return Padding(
                                       padding: const EdgeInsets.symmetric(vertical: 2.0),
                                       child: Row(
@@ -207,7 +204,7 @@ class PolygonInfoPanel extends StatelessWidget {
       child: Row(
         children: [
           Text(
-            label,
+            label == 'Ubekendt' ? 'Unknown' : label,
             style: TextStyle(
               fontWeight: FontWeight.bold,
               color: Colors.orange.shade800,

--- a/lib/ui/widgets/polygon_info_panel.dart
+++ b/lib/ui/widgets/polygon_info_panel.dart
@@ -84,13 +84,13 @@ class PolygonInfoPanel extends StatelessWidget {
             ),
             const Divider(),
             Flexible(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.all(16.0),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Expanded(
-                      flex: 1,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    flex: 1,
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.all(16.0),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -113,9 +113,12 @@ class PolygonInfoPanel extends StatelessWidget {
                         ],
                       ),
                     ),
-                    const SizedBox(width: 16),
-                    Expanded(
-                      flex: 1,
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    flex: 1,
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.all(16.0),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -130,52 +133,60 @@ class PolygonInfoPanel extends StatelessWidget {
                             future: _fetchExhibits(polygon.id),
                             builder: (context, snapshot) {
                               if (snapshot.connectionState == ConnectionState.waiting) {
-                                return const Text('Fetching exhibits...', style: TextStyle(fontSize: 16));
+                                return const Text(
+                                  'Fetching exhibits...',
+                                  style: TextStyle(fontSize: 16),
+                                );
                               } else if (snapshot.hasError) {
                                 return Text('Error: ${snapshot.error}');
                               } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
                                 return const Text('No exhibits on display.');
                               } else {
                                 final exhibits = snapshot.data!;
-                                return SizedBox(
-                                  height: 150,
-                                  child: ListView.builder(
-                                    itemCount: exhibits.length,
-                                    itemBuilder: (context, index) {
-                                      final exhibit = exhibits[index];
+                                return ListView.builder(
+                                  shrinkWrap: true,
+                                  physics: const NeverScrollableScrollPhysics(),
+                                  itemCount: exhibits.length,
+                                  itemBuilder: (context, index) {
+                                    final exhibit = exhibits[index];
 
-                                      final title = (exhibit['titles'] as List?)?.isNotEmpty == true
-                                          ? exhibit['titles'][0]['title'] ?? 'Untitled'
-                                          : 'Untitled';
+                                    final title = (exhibit['titles'] as List?)?.isNotEmpty == true
+                                        ? exhibit['titles'][0]['title'] ?? 'Untitled'
+                                        : 'Untitled';
 
-                                      final artist = (exhibit['artist'] as List?)?.isNotEmpty == true
-                                          ? exhibit['artist'][0] ?? 'Unknown artist'
-                                          : 'Unknown artist';
-                                      
-                                      final String thumbnail = exhibit['image_thumbnail'];
-                                      final String frontendUrl = exhibit['frontend_url'];
-                                      return Padding(
-                                        padding: const EdgeInsets.symmetric(vertical: 2.0),
-                                        child: Row(
-                                          crossAxisAlignment: CrossAxisAlignment.start,
-                                          children: [
-                                            Expanded(
-                                              child: _buildInfoRow(context, artist, title, thumbnail, frontendUrl),
+                                    final artist = (exhibit['artist'] as List?)?.isNotEmpty == true
+                                        ? exhibit['artist'][0] ?? 'Unknown artist'
+                                        : 'Unknown artist';
+
+                                    final String thumbnail = exhibit['image_thumbnail'];
+                                    final String frontendUrl = exhibit['frontend_url'];
+                                    return Padding(
+                                      padding: const EdgeInsets.symmetric(vertical: 2.0),
+                                      child: Row(
+                                        crossAxisAlignment: CrossAxisAlignment.start,
+                                        children: [
+                                          Expanded(
+                                            child: _buildInfoRow(
+                                              context,
+                                              artist,
+                                              title,
+                                              thumbnail,
+                                              frontendUrl,
                                             ),
-                                          ],
-                                        ),
-                                      );
-                                    },
-                                  ),
+                                          ),
+                                        ],
+                                      ),
+                                    );
+                                  },
                                 );
                               }
                             },
-                          )
+                          ),
                         ],
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
           ],

--- a/lib/ui/widgets/polygon_info_panel.dart
+++ b/lib/ui/widgets/polygon_info_panel.dart
@@ -19,7 +19,7 @@ class PolygonInfoPanel extends StatelessWidget {
 
   Future<List<dynamic>> _fetchExhibits(String roomId) async {
     try {
-      final response = await apiService.getArtworksByRoomId(roomId);
+      final response = await apiService.getArtwork(roomId, roomIdQuery: true);
       return response.data['items'] as List<dynamic>;
     } catch (e) {
       throw Exception('Failed to load exhibits: $e');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -541,6 +541,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "8582d7f6fe14d2652b4c45c9b6c14c0b678c2af2d083a11b604caeba51930d79"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.16"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   mockito: ^5.4.5
   flutter_dotenv: ^5.2.1
   toastification: ^3.0.2
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request introduces enhancements to the `PolygonInfoPanel` widget, refines the API service, and improves the user experience in the `HomeScreen`. It also updates dependencies to support new functionality. The most significant changes include adding exhibit fetching and display functionality to the `PolygonInfoPanel`, modifying the API service to handle room-specific queries, and refining the handling of optional values in the `HomeScreen`.

### Enhancements to `PolygonInfoPanel`:

* Added functionality to fetch and display exhibits for a room using the `APIService`. Exhibits are shown with their title, artist, thumbnail, and a clickable frontend URL if available. [[1]](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aR2-L21) [[2]](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aR86-R196) [[3]](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aR222-R262)
* Updated `_buildInfoRow` to support thumbnails and clickable links, with a confirmation dialog for opening external URLs.
* Improved label handling by replacing "Ubekendt" with "Unknown" for better user clarity.

### Changes to API Service:

* Modified the `getArtwork` method to include a `roomIdQuery` parameter, allowing room-specific queries. Updated error messages to reflect the query type.

### Improvements in `HomeScreen`:

* Refined the conditional check for `_selectedPolygon` to handle null values safely, preventing potential runtime errors.

### Dependency Updates:

* Added the `url_launcher` package to enable opening external links for exhibits.