### PR TITLE
Fix: bug when pan/zoom with fetching artworks 

### DIFF
--- a/lib/ui/widgets/polygon_info_panel.dart
+++ b/lib/ui/widgets/polygon_info_panel.dart
@@ -3,7 +3,7 @@ import 'package:indoor_crowded_regions_frontend/services/api_service.dart';
 import '../../models/polygon_area.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class PolygonInfoPanel extends StatelessWidget {
+class PolygonInfoPanel extends StatefulWidget {
   final PolygonArea polygon;
   final VoidCallback onClose;
   final void Function(String roomId)? onShowRoute;
@@ -14,6 +14,30 @@ class PolygonInfoPanel extends StatelessWidget {
     required this.onClose,
     required this.onShowRoute,
   });
+
+  @override
+  PolygonInfoPanelState createState() => PolygonInfoPanelState();
+}
+
+class PolygonInfoPanelState extends State<PolygonInfoPanel> {
+  late Future<List<dynamic>> _exhibitFuture;
+  late String _lastPolygonId;
+
+  @override
+  void initState() {
+    super.initState();
+    _lastPolygonId = widget.polygon.id;
+    _exhibitFuture = _fetchExhibits(_lastPolygonId);
+  }
+
+  @override
+  void didUpdateWidget(covariant PolygonInfoPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.polygon.id != _lastPolygonId) {
+      _lastPolygonId = widget.polygon.id;
+      _exhibitFuture = _fetchExhibits(_lastPolygonId);
+    }
+  }
 
   final APIService apiService = APIService();
 
@@ -60,7 +84,7 @@ class PolygonInfoPanel extends StatelessWidget {
                 children: [
                   ElevatedButton.icon(
                     onPressed: () {
-                      onShowRoute!(polygon.id);
+                      widget.onShowRoute!(widget.polygon.id);
                     },
                     icon: const Icon(Icons.alt_route),
                     label: const Text("Show Route"),
@@ -76,7 +100,7 @@ class PolygonInfoPanel extends StatelessWidget {
                   ),
                   IconButton(
                     icon: const Icon(Icons.close, color: Colors.orange),
-                    onPressed: onClose,
+                    onPressed: widget.onClose,
                     tooltip: 'Close Panel',
                   ),
                 ],
@@ -101,13 +125,13 @@ class PolygonInfoPanel extends StatelessWidget {
                                   color: Colors.orange.shade800,
                                 ),
                           ),
-                          _buildInfoRow(context, 'Name', polygon.name),
-                          _buildInfoRow(context, 'Type', polygon.type),
-                          if (polygon.additionalData != null) ...[
+                          _buildInfoRow(context, 'Name', widget.polygon.name),
+                          _buildInfoRow(context, 'Type', widget.polygon.type),
+                          if (widget.polygon.additionalData != null) ...[
                             _buildInfoRow(
                               context,
                               'Floor',
-                              polygon.additionalData!['floor']?.toString() ?? 'N/A',
+                              widget.polygon.additionalData!['floor']?.toString() ?? 'N/A',
                             ),
                           ],
                         ],
@@ -130,7 +154,7 @@ class PolygonInfoPanel extends StatelessWidget {
                                 ),
                           ),
                           FutureBuilder<List<dynamic>>(
-                            future: _fetchExhibits(polygon.id),
+                            future: _exhibitFuture,
                             builder: (context, snapshot) {
                               if (snapshot.connectionState == ConnectionState.waiting) {
                                 return const Text(

--- a/lib/ui/widgets/polygon_info_panel.dart
+++ b/lib/ui/widgets/polygon_info_panel.dart
@@ -8,7 +8,7 @@ class PolygonInfoPanel extends StatefulWidget {
   final VoidCallback onClose;
   final void Function(String roomId)? onShowRoute;
 
-  PolygonInfoPanel({
+  const PolygonInfoPanel({
     super.key,
     required this.polygon,
     required this.onClose,


### PR DESCRIPTION
This pull request refactors the `PolygonInfoPanel` widget in `lib/ui/widgets/polygon_info_panel.dart` to transition it from a `StatelessWidget` to a `StatefulWidget`. The changes enable dynamic updates when the `polygon` data changes, improving the widget's reactivity and functionality.

### Refactor to StatefulWidget:

* Converted `PolygonInfoPanel` from a `StatelessWidget` to a `StatefulWidget` and introduced a new `PolygonInfoPanelState` class to manage state. This allows the widget to track changes in the `polygon` data and dynamically update the UI. (`[[1]](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aL6-R6)`, `[[2]](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aR18-R41)`)

### State Management:

* Added `_exhibitFuture` and `_lastPolygonId` state variables to cache the exhibits and track the current polygon ID, respectively. (`[lib/ui/widgets/polygon_info_panel.dartR18-R41](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aR18-R41)`)
* Implemented `initState` to initialize `_exhibitFuture` with data fetched for the initial polygon. (`[lib/ui/widgets/polygon_info_panel.dartR18-R41](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aR18-R41)`)
* Overrode `didUpdateWidget` to detect changes in the `polygon` ID and refresh `_exhibitFuture` accordingly. (`[lib/ui/widgets/polygon_info_panel.dartR18-R41](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aR18-R41)`)

### Widget Updates:

* Updated all references to `polygon` and its properties to use `widget.polygon` to reflect the transition to a `StatefulWidget`. (`[[1]](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aL63-R87)`, `[[2]](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aL79-R103)`, `[[3]](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aL104-R134)`)
* Replaced direct calls to `_fetchExhibits` with `_exhibitFuture` in the `FutureBuilder` to leverage the cached future and avoid redundant API calls. (`[lib/ui/widgets/polygon_info_panel.dartL133-R157](diffhunk://#diff-938ef4e9a3b1dd4e448379a43f2d9fcb2796177ccdfe18d6c61111e8f662df3aL133-R157)`)