### PR TITLE
feat: exhibit cards and dialog when interacting, also colorscheme. 

### DIFF
--- a/exhibit_json_example.json
+++ b/exhibit_json_example.json
@@ -1,0 +1,496 @@
+{
+    items: [
+    {
+    id: "1170012466_object",
+    created: "2020-03-21T10:45:15Z",
+    modified: "2025-04-10T09:06:12Z",
+    responsible_department: "Den Kongelige Maleri- og Skulptursamling",
+    content_description: [
+    "Den faldende i billedets midte er en gentagelse af Cornelis Cornelisz' egen 'Ikaros', stukket af Hendrick Goltzius i 1588 (Holl. 306-09).",
+    "Lignende figur af den stående mand til venstre i to andre værker af Cornelis Cornelisz: 'Drieluik met de Kindermoord te Bethlehem, de Aanbidding der heders en de Aanbidding der koningen', 1591 + 'De kindermoord te Bethlehem', 1591 (Maurits - Prins van Oranje, Rijksmuseum, Amsterdam, 2000, p. 148 + 321)"
+    ],
+    literary_reference: [
+    "(Hesoid: Theogonia,617-643 og Ovid: Metamorfoser I, 151-155) (Hesoid: Theogonia,617-643 and Ovid: Metamorphoses I) I Karel van Manders Wtlegginghe (Schilder-Boeck, 1604) fol. IV recto udlægges Titanernes Fald på følgende måde: "Nu dees Poeetsche Reusen zijn niet anders te verstaen / als hooveerdighe Tyrannen / die met hun Swacke versterflijcke macht verwaendlijc den onsterflijcken Godt in almachtigheydt meenen / oft schijnen te willen vergelijcken / waerom sy eyndtlijck gheblixemt van de Godelijcke rechtveerdighe gramschap / t'same met hunnen hoogmoedt werden uytgheroept...". (Kan nogenlunde oversættes til: "Disse poetiske giganter kan ikke forstås på anden måde end som hovmodige tyranner, der i deres svage og dødelige magt dristigt mener at kunne, eller ser ud til at ville, sammenligne sig med den udødelige Guds almægtighed, hvorfor de slutteligt bliver ramt af lynet fra Guds retfærdige vrede, og sammen med deres hovmod bliver fordrevet...")"
+    ],
+    current_location_name: "Sal 205",
+    acquisition_date: "1621-01-01T00:00:00Z",
+    acquisition_date_precision: "1621-12-31",
+    dimensions: [
+    {
+    notes: "2390 x 3070 mm",
+    part: "Netto",
+    type: "højde",
+    unit: "centimeter",
+    value: "239"
+    },
+    {
+    notes: "2390 x 3070 mm",
+    part: "Netto",
+    type: "bredde",
+    unit: "centimeter",
+    value: "307"
+    }
+    ],
+    documentation: [
+    {
+    title: "Hollandsk malerkunst",
+    author: "Karl Madsen",
+    notes: "204",
+    shelfmark: "1105",
+    year_of_publication: "1891"
+    },
+    {
+    title: "De bronnen van Carel van Mander: voor "Het leven der doorluchtighe nederlandtsche en hoogduytsche schilders"",
+    author: "H. E. Greve",
+    notes: "207",
+    shelfmark: "1954",
+    year_of_publication: "1903"
+    },
+    {
+    title: "Cornelis Cornelisz van Haarlem 1562-1638: a monograph and catalogue raisonné",
+    author: "Pieter J.J. van Thiel",
+    notes: "30, 71, 76-77, 97, 153, 159, 177, 198, 325-327 kat. 87, pl. 16-18, farveplanche 1",
+    shelfmark: "2000-010",
+    year_of_publication: "1999"
+    },
+    {
+    title: "Clinch: danske kunstnere markerer Kunstakademiets 250 års jubilæum på Statens Museum for Kunst",
+    author: "Sven Bjerkhof",
+    notes: "Omtalt p. 66-67. Ill. p. 65 udstillingsfotografi og p. 67 detalje",
+    shelfmark: "2004-276",
+    year_of_publication: "2004"
+    },
+    {
+    title: "SMK highlights: Statens Museum for Kunst",
+    author: "Sven Bjerkhof",
+    notes: "omt. og afb. p. 33",
+    shelfmark: "2005-071",
+    year_of_publication: "2005"
+    },
+    {
+    title: "De Nationale Konst-Gallery en het Koninklijk Museum",
+    author: "E.W. Moes",
+    notes: "77-78, 107, 159, 176-77",
+    shelfmark: "2566",
+    year_of_publication: "1909"
+    },
+    {
+    title: "Frederiksborg: Bd. 2: Slottets historie",
+    author: "Francis Beckett",
+    notes: "260, nr. 217",
+    shelfmark: "2910",
+    year_of_publication: "1914"
+    },
+    {
+    title: "From Pisanello to Cézanne: master drawings from the Museum Boymans-van Beuningen",
+    author: "Ubekendt",
+    notes: "68",
+    shelfmark: "54315",
+    year_of_publication: "1990"
+    },
+    {
+    title: "Dawn of the golden age: Northern Netherlandish art, 1580-1620",
+    author: "Wouter Kloek",
+    notes: "afb. (f) p. 202, kat. 5 p. 335-36 (ill.) (Van Thiel foreslår, at scenen forestiller Lucifers fald)",
+    shelfmark: "55283",
+    year_of_publication: "1993"
+    },
+    {
+    title: "Geschiedkundige aanteekeningen over haarlemsche schilders: en andere beoefenaren van de beeldende kunsten, voorafgegaan door eene kort geschiedenis van het schilders of St. Lucas gild aldaar",
+    author: "A. van der Willigen",
+    notes: "99",
+    shelfmark: "588",
+    year_of_publication: "1866"
+    },
+    {
+    title: "Gods, saints and heroes: Dutch painting in the age of Rembrandt: [National Gallery of Art, Washington, November 2, 1980 - January 4, 1981: The Detroit Institute of Arts, February 16 - April 19, 1981: Rijksmuseum, Amsterdam, May 18 - July 19, 1981]",
+    author: "Ubekendt",
+    notes: "78-79, kat. nr. 2",
+    shelfmark: "64173",
+    year_of_publication: "cop. 1980"
+    },
+    {
+    title: "Schilderijen voor het stadhuis Haarlem: 16e en 17e eeuw kunstopdrachten ter verfraaiing",
+    author: "P. Biesboer",
+    notes: "34",
+    shelfmark: "86-103",
+    year_of_publication: "1983"
+    },
+    {
+    title: "Mythologie et maniérisme: Italie, Bavière, Fontainebleau, Prague, Pays-Bas: peinture et dessins",
+    author: "Andrée de Bosque",
+    notes: "afb. p. 125, 126",
+    shelfmark: "87-149",
+    year_of_publication: "1985"
+    },
+    {
+    title: "Joachim Wtewael and Dutch mannerism",
+    author: "Anne W. Lowenthal",
+    notes: "103",
+    shelfmark: "87-38",
+    year_of_publication: "cop. 1986"
+    },
+    {
+    title: "Christian IV og Europa: den 19. Europarådsudstilling, Danmark 1988",
+    author: "Steffen Heiberg",
+    notes: "Olaf Koester, Christian IV og billedkunstens Europa, p. 314, kat. nr. 1016, afb. p. 313",
+    shelfmark: "88-222",
+    year_of_publication: "1988"
+    },
+    {
+    title: "Renæssancen i 1500-tallet",
+    author: "Nils Ohrt",
+    notes: "p. 10-11, kat. nr. 28, afb. (F) p. 10",
+    shelfmark: "96-749",
+    year_of_publication: "1996"
+    },
+    {
+    title: "De 'Heydensche Fabulen' in de Noordnederlandse schilderkunst, circa 1590-1670: proefschrift ter verkrijging van de graad van Doctor in de Letteren aan de Rijksuniversiteit te Leiden... 9 april 1986",
+    author: "Eric Jan Sluijter",
+    notes: "p. 347 note 15-2",
+    shelfmark: "97106",
+    year_of_publication: "[1986]"
+    },
+    {
+    title: "Statens Museum for Kunst: 1827-1952",
+    author: "Villads Villadsen",
+    notes: "ill. (s/h) p.27",
+    shelfmark: "98-419",
+    year_of_publication: "1998"
+    },
+    {
+    title: "Christian 4. og Frederiksborg",
+    author: "Ubekendt",
+    notes: "afb. p. 298-299",
+    shelfmark: "C 31123",
+    year_of_publication: "2006"
+    },
+    {
+    title: "Pieter Isaacsz (1568-1625): court painter, art dealer and spy",
+    author: "Ubekendt",
+    notes: "afb. p. 156, ill. 77, omt. p. 157",
+    shelfmark: "C 37345",
+    year_of_publication: "2007"
+    },
+    {
+    title: "Reframing the Danish Renaissance: papers from an International Conference in Copenhagen 28 September - 1 October 2006",
+    author: "Ubekendt",
+    notes: "Noldus, Badeloch Vera: Art and Music on Demand - A Portrait of the Danish Diplomat Jonas Charisius and his Mission to the Dutch Republic pp. 279-300. Ill. p. 284, fig. 3",
+    shelfmark: "C 48011",
+    year_of_publication: "2011"
+    },
+    {
+    title: "Cornelis Corneliszoon van Haarlem (1562-1638): patrons, friends and Dutch humanists",
+    author: "Julie L. McGee",
+    notes: "223-24",
+    shelfmark: "D 21511 B",
+    year_of_publication: "1991"
+    },
+    {
+    title: "Fra vore Museers Barndom: Kunstkammeret. Dets Stiftelse og ældste Historie",
+    author: "H.C. Bering Liisberg",
+    notes: "140",
+    shelfmark: "D 3702",
+    year_of_publication: "1897"
+    },
+    {
+    title: "Werner Jacobsz. van den Valckert",
+    author: "P.J.J van Thiel",
+    notes: "175 n66"
+    },
+    {
+    title: "Cornelis Cornelisz van Haerlem",
+    author: "F. Wedekind",
+    notes: "VI, 20",
+    year_of_publication: "1911"
+    },
+    {
+    title: "Cornelis Cornelisz. van Haarlem",
+    author: "C.J Gonnet",
+    notes: "177"
+    },
+    {
+    title: "Cornelis van Haarlem en de Hollandsche laat-manieristische schilderkunst",
+    author: "Wolfgang Stechow",
+    notes: "81"
+    },
+    {
+    title: "Albrecht Dürer in der Kunst und im Kunsturteil uim 1600",
+    author: "H. Kauffmann",
+    notes: "40-42",
+    year_of_publication: "1954"
+    },
+    {
+    title: "Cornelis Cornelisz. van Haarlam as a Draftsman",
+    author: "P.J.J. van Thiel",
+    notes: "128, 130, 131"
+    },
+    {
+    title: "Mariage Symbolism in a Musical Party by Jan Miense Molenaer",
+    author: "P.J.J. van Thiel",
+    notes: "96-97"
+    },
+    {
+    title: "Cornelis Cornelisz van Haarlem; his first ten years as a painter, 1582-1592",
+    author: "P.J.J. van Thiel",
+    notes: "76",
+    year_of_publication: "1985"
+    },
+    {
+    title: "La réhabilitation de manierisme hollandais. Deuz tableaux de Cornelis van Haarlem",
+    author: "P. J. J. van Thiel",
+    notes: "KMS1 omtales p. 117"
+    },
+    {
+    title: "Hont Hortstiana",
+    author: "E.K.J Reznicek",
+    notes: "174 og n18"
+    },
+    {
+    title: "Titanernes fald - og genoprejsning",
+    author: "Henrik Bjerre",
+    notes: "p. 70-81, ill. p. 70 (detaille), afb. (f) p. 73, røntgenoptagelse p. 76-77, p. 81 (detaille)",
+    year_of_publication: "1991"
+    },
+    {
+    title: "Het Schilderboek",
+    author: "Karel van Mander",
+    notes: "p. 368 (med reference til P.J.J. van Thiels "Cornelis Cornelisz. van Haarlem - his first ten years as a painter 1584-1592" i G. Cavalli-Björkman (red.) Netherlandish Mannerism, Stockholm 1985. p. 73-84 afvisers det, at KMS1 er identisk med den "Val van Lucifer" som v.Mander nævner i Jacob Rauwerts eje (p.364)).",
+    year_of_publication: "1995 1995"
+    },
+    {
+    title: "100 mesterværker",
+    author: "Eva Friis",
+    notes: "tekst skrevet af Hanne Jönsson p. 52, afb. (F) p. 53",
+    shelfmark: "k1996-233",
+    year_of_publication: "1996"
+    },
+    {
+    title: "The New Hollstein Dutch and Flemish etchings, engravings and woodcuts 1450-1700, The Muller dynasty, part I-III",
+    author: "Jan Piet Filedt Kok",
+    notes: "vol. II p. 15 og note 15",
+    shelfmark: "k1999-249",
+    year_of_publication: "1999"
+    },
+    {
+    title: "Hendrick Goltzius (1558-1617): tekeningen, prenten en schilderijen",
+    author: "Ubekendt",
+    notes: "p. 98 under kat. 33 og n62",
+    shelfmark: "k2003-329",
+    year_of_publication: "2003"
+    },
+    {
+    title: "Vénus et Adonis: de Cornelis van Haarlem",
+    author: "Caroline Joubert",
+    notes: "Omt, p. 8-9, afb. p. 8, fig. 6",
+    shelfmark: "k2006-089",
+    year_of_publication: "2006"
+    },
+    {
+    title: "50 værker du skal se på SMK",
+    author: "Camilla Jalving",
+    notes: "Omt. 33, afb. 32",
+    year_of_publication: "2024"
+    },
+    {
+    title: "50 Favourites in the SMK Collection",
+    author: "Camilla Jalving",
+    notes: "omt. 33, afb. 32",
+    year_of_publication: "2024"
+    }
+    ],
+    exhibitions: [
+    {
+    exhibition: "Clinch!",
+    date_start: "2004-04-01T00:00:00.000Z",
+    date_end: "2004-11-28T00:00:00.000Z",
+    venue: "Sølvgade"
+    },
+    {
+    exhibition: "Renæssancen i 1500-tallet",
+    date_start: "1996-10-26T00:00:00.000Z",
+    date_end: "1997-03-09T00:00:00.000Z",
+    venue: "Nivaagaards Malerisamling"
+    },
+    {
+    exhibition: "100 Mesterværker",
+    date_start: "1996-06-23T00:00:00.000Z",
+    date_end: "1996-08-04T00:00:00.000Z",
+    venue: "Sølvgade"
+    },
+    {
+    exhibition: "Christian IV og Europa : den 19. Europarådsudstilling",
+    date_start: "1988-03-30T00:00:00.000Z",
+    date_end: "1988-09-25T00:00:00.000Z",
+    venue: "Sølvgade"
+    }
+    ],
+    labels: [
+    {
+    text: "I den romerske digter Ovids Metamorfoser fortælles historien om den herskende gudeslægt bestående af titanerne, kykloperne og giganterne, som blev udfordret af de olympiske guder med Zeus i spidsen til en drabelig kosmisk kamp, den såkaldte titanomachia.
+    
+    Kampen endte med titanernes nederlag og den af Zeus befalede nedstyrtning til underverdenens Tartaros, hvor de blev skyld i jordskælv og vulkaners udbrud.
+    
+    Kunstneriske idealer
+    Cornelis Cornelisz van Haarlem har udlevet alle sine kunstneriske idealer i de nøgne muskuløse kroppe og i de komplicerede stillinger. Studier efter nøgenmodel blev først almindeligt i slutningen af 1600-tallet, men i Haarlem stiftede Karel van Mander (1548-1606) et akademi, hvor man ikke alene dyrkede den akademiske nøgenakt som øvelsesmotiv, men også diskuterede emner af kunstteoretisk natur.
+    
+    Et eksempel på Haarlem-manierismen
+    Maleriet er et eksempel på Haarlem-manierismen. Manierisme er betegnelsen for den stilart mellem renæssancen og barokken, hvor det artificielle og sensuelle var i højsædet. Stilen blev blandt andet fremelsket ved Rudolf 2.s (1552-1612) hof i Prag og bredte sig herfra nordpå, hvor vores egen Christian 4. (1557-1648) tog den til sig. Titanernes fald var blandt de nederlandske malerier, som han erhvervede i 1621.",
+    type: "OTHERTEXT",
+    source: "Eva de la Fuente Pedersen",
+    date: "2005-01-01T00:00:00.000Z"
+    },
+    {
+    text: "Mandekroppen i frit fald Cornelis Cornelisz. van Haarlem (1562-1638), Titanernes fald (1588) I 1621 købte kong Christian d. 4 kunstværket Titanernes Fald, og i slutningen af 1980erne kom det frem i lyset fra SMKs magasin. Siden har den hollandske maler Cornelis Cornelisz. van Haarlems store maleri været et af de mest elskede værker i samlingen på SMK. Der er fuldt knald på Cornelis Cornelisz. van Haarlems 2,5x3 meter store lærred, hvor de nøgne mandekroppe falder oven i hinanden. Udover at Cornelis Cornelisz. van Haarlem her får udlevet alle sine kunstneriske idealer i arbejdet med at gengive den nøgne muskuløse krop, så er Titanernes Fald også en fortælling om titanernes, kyklopernes og giganternes kosmiske kamp mod de græske guder med Zeus i spidsen. Som det tydeligt ses, led de et sviende nederlag og styrtede på Zeus’ befaling ned i underverdenen Tartaros, hvor de var årsag til jordskælv og vulkanudbrud. En hyldest til mandekroppen ”Værket var hypermoderne i sin samtid. Både det at have evnen til at male figurer i så svære positioner og menneskekroppe i frit fald. Det var imponerende,” fortæller museumsinspektør, Eva de la Fuente Pedersen. I midten af værket danner figurerne i forgrunden en ramme og bag dem åbner der sig flere planer ind i billedet. Dette er en typisk malemåde i tiden. ”De falder jo ned i Helvede, og man kan se lyset fra solen, der skinner ned i afgrunden. Det er et næsten science fictionagtigt formsprog, kunstneren har brugt. De vælter jo nærmest ud i hovedet på os, og ved brug af både farverne og rummet suger han os ind i et uendeligt dybt rum,” siger Eva de la Fuente Pedersen. Og så er der sommerfuglene, der er blevet meget strategisk placeret. Nogle gange bruges sommerfulgle som symbol for sjælen, der flyver op, men det er, ifølge Eva de la Fuente Pedersen, ikke den betydning, de har her. ”Her er både sommerfugle og insekter i megaformat, og jeg tror de hører til de væsner, man forestillede sig boede nede i Helvede. Insekter blev forbundet med ild på dette tidspunkt, hvor man troede, at de blev født af ild, fordi de sværmer omkring og ind i lyset.” Titanernes Fald er et hovedværk fra Cornelis Cornelisz. van Haarlems ungdomstid og er et klassisk eksempel på det, der i kunsthistorien kaldes for Haarlem manierisme. Her er de komplicerede og overdrevne kropsgengivelser omdrejningspunktet og Cornelis Cornelisz. van Haarlem gjorde sig netop umage med at vise, hvor dygtig han var til det netop det. Andre museer Cornelis Cornelisz. van Haarlems værker kan også ses på Rijksmuseet i Amsterdam, Holland, Frans Hals museet i Haarlem, Holland, Louvre museet, Paris, Frankrig, og Staatliche Kunstsamlungen, Dresden, Tyskland.",
+    type: "OTHERTEXT",
+    source: "Annette Rosenvold Hvidt",
+    date: "2018-09-11T00:00:00.000Z"
+    },
+    {
+    text: "I Ovids Forvandlinger fortælles om Kronos og titanerne, den herskende gudeslægt, der udfordrede de olympiske guder i en kosmisk kamp. Titanerne tabte og blev nedstyrtet til underverdenen, Tartaros. Titanernes leder, Kronos, blev verdenshersker ved at kastrere sin far Uranus. Magtbegær og paranoia fik ham til at vende sig mod sine brødre, kykloperne og de hundredarmede. Men mest frygtede han sine børn og åd dem, en for en, lige efter fødslen. Motivet minder ejeren og alle os andre om de farer, som truer, hvis man i jagten på magten tilsidesætter alle medmenneskelige hensyn for egen vindings skyld. Cornelis Cornelisz. van Haarlems maleri er et eksempel på den såkaldte Haarlem-manierisme, hvor det kunstige og sensuelle var i højsædet. Stilen blev fremelsket ved Rudolf 2.s hof i Prag og bredte sig herfra nordpå, hvor Christian 4. tog den til sig.",
+    type: "CATALOGUETEXT",
+    source: "Peter Nørgaard Larsen",
+    date: "2019-11-07T00:00:00.000Z"
+    },
+    {
+    text: "Vi ser nogle nøgne mænd, der falder råbende og skrigende ned i dybet. Figurerne hvirvler hjælpeløse ned imod os. Kunstneren har gjort meget for at vise, hvor dygtig han er til at skildre kroppen fra alle nu lige og umulige vinkler. Titanerne, der efter at have tabt kampen om herre dømmet over jorden til Olympens guder, bliver kastet i Tartaros, en underverden endnu længere nede end Hades i græsk mytologi. På den tid, maleriet er malet, så man titanerne som symbolske figurer på dem, der ikke kunne styre deres drifter. Figurerne har kønnet dækket af sommerfugle og guldsmede, muligvis symboler på homoseksualitet. Nok kastes titanerne ned i underverdenen, men her ser det ud, som om de kastes ned til os, og der er både intensitet og medlidenhed i skildringen af dem.",
+    type: "CATALOGUETEXT",
+    source: "Henrik Holm & Louise Wolthers"
+    }
+    ],
+    materials: [
+    "Lærred"
+    ],
+    object_names: [
+    {
+    name: "Maleri"
+    }
+    ],
+    production: [
+    {
+    creator: "Haarlem, Cornelis Cornelisz. van",
+    creator_forename: "Cornelis Cornelisz. van",
+    creator_surname: "Haarlem",
+    creator_date_of_birth: "1562-01-01T00:00:00.000Z",
+    creator_date_of_death: "1638-01-01T00:00:00.000Z",
+    creator_nationality: "Hollandsk",
+    creator_gender: "MALE",
+    creator_lref: "1563_person"
+    }
+    ],
+    production_date: [
+    {
+    start: "1588-01-01T00:00:00.000Z",
+    end: "1590-12-31T00:00:00.000Z",
+    period: "1588-1590"
+    }
+    ],
+    related_objects: [
+    {
+    title: "De fire himmelstormere - Ikaros",
+    reference: "KKSgb1045"
+    }
+    ],
+    techniques: [
+    "Olie på lærred"
+    ],
+    titles: [
+    {
+    title: "Titanernes fald",
+    type: "museumstitel",
+    language: "dansk"
+    }
+    ],
+    notes: [
+    "Tidligere inventarnumre: 
+    - papirer vedr. de tidligste indkøb af kunst 1621 Lit. C.C. nr. 217
+    - Kunstkammerets Inventar 1690 p. 353 nr. 36 (se Bering Liisberg p. 140)
+    - KMS' kunstk. protokol: s. 228 s. 82
+    
+    Katalognumre: 
+    - kat. 1922 nr. 188
+    - kat. 1946 nr. 134"
+    ],
+    number_of_parts: 1,
+    object_history_note: [
+    "(P.J.J. van Thiel har foreslået, Van Thiel (1993) 336, at KMS1 forestiller 'Lucifers fald' og er identisk med det maleri Van Mander i Het Schilder-Boeck omtaler fra Jacob Rauwerts samling. I så fald blev maleriet solgt 29. august 1612 fra sønnen Claes Rauwerts eje - "1 [stuck per Mr. C] val der Engelen 455:0:-" til den amsterdamske kunsthandler og -samler Barent van Someren.)
+    
+    Placeringshistorie:
+    - Magasineret
+    - 1886, febr.: Kronborg
+    - 1914, okt.: retur
+    - 1922: loftsbillede i sal XXIX i museets gamle samling
+    - 1929, juni: til Kronborg
+    - 1951, 14. marts: tilbage
+    - 1953, 26. aug.: til Kronborg
+    - 1954, april: tilbage
+    - 1959, april: til Kronborg
+    - 1977, 29. febr.: på liste ført af slotsforvalteren
+    - 1982, 9. juni: Sølvgade"
+    ],
+    object_number: "KMS1",
+    object_url: "https://api.smk.dk/api/v1/art/?object_number=kms1",
+    frontend_url: "https://open.smk.dk/artwork/image/kms1",
+    iiif_manifest: "https://api.smk.dk/api/v1/iiif/manifest/?id=kms1",
+    enrichment_url: "https://enrichment.api.smk.dk/api/enrichment/KMS1",
+    similar_images_url: "https://similar.api.smk.dk/similar/?object_number=KMS1",
+    production_dates_notes: [
+    "Værkdatering: 1588-1590",
+    "Påbegyndt: fagligt skøn afsluttet: fagligt skøn"
+    ],
+    public_domain: true,
+    rights: "https://creativecommons.org/publicdomain/zero/1.0/",
+    on_display: true,
+    alternative_images: [
+    {
+    mime_type: "image/tiff",
+    iiif_id: "https://iip.smk.dk/iiif/jp2/n870zr63k_KMS1.tif.jp2",
+    iiif_info: "https://iip.smk.dk/iiif/jp2/n870zr63k_KMS1.tif.jp2/info.json",
+    width: 7328,
+    height: 5919,
+    size: 44879943.448275864,
+    thumbnail: "https://iip-thumb.smk.dk/iiif/jp2/n870zr63k_KMS1.tif.jp2/full/!1024,/0/default.jpg",
+    native: "https://iip.smk.dk/iiif/jp2/n870zr63k_KMS1.tif.jp2/full/full/0/native.jpg",
+    orientation: "landscape"
+    }
+    ],
+    image_mime_type: "image/tiff",
+    image_iiif_id: "https://iip.smk.dk/iiif/jp2/9g54xm869_KMS1-cropped.tif.jp2",
+    image_iiif_info: "https://iip.smk.dk/iiif/jp2/9g54xm869_KMS1-cropped.tif.jp2/info.json",
+    image_width: 7174,
+    image_height: 5536,
+    image_size: 41094060,
+    image_thumbnail: "https://iip-thumb.smk.dk/iiif/jp2/9g54xm869_KMS1-cropped.tif.jp2/full/!1024,/0/default.jpg",
+    image_native: "https://api.smk.dk/api/v1/download/W3siaW1nX3VybCI6Imh0dHBzOi8vaWlwLnNtay5kay9paWlmL2pwMi85ZzU0eG04NjlfS01TMS1jcm9wcGVkLnRpZi5qcDIvZnVsbC9mdWxsLzAvbmF0aXZlLmpwZyIsInB1YmxpY19kb21haW4iOnRydWUsIm9iamVjdF9udW1iZXIiOiJLTVMxIiwibnVtIjoiIn1d/KMS1.jpg",
+    image_orientation: "landscape",
+    image_hq: true,
+    has_3d_file: false,
+    has_image: true,
+    colors: [
+    "#222222",
+    "#230b09",
+    "#170e06",
+    "#ec6449",
+    "#fcaa6b",
+    "#b97438",
+    "#77733d",
+    "#956830",
+    "#593d1c"
+    ],
+    suggested_bg_color: [
+    "#ec6449"
+    ],
+    entropy: 9.763483,
+    contrast: 3.1605868,
+    saturation: 4.683906,
+    colortemp: 5.369496,
+    brightness: 3.6086755,
+    media_video: [
+    "{"title":"Blikket i kunsten: Titanernes Fald","url":"https://youtu.be/rcIr6zFyZxA","language":"all"}"
+    ],
+    artist: [
+    "Cornelis Cornelisz. van Haarlem"
+    ]
+    }
+    ]
+    }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -4,7 +4,7 @@ import 'package:indoor_crowded_regions_frontend/ui/components/error_toast.dart';
 
 class APIService {
   final dio = Dio(BaseOptions(
-    baseUrl: dotenv.env['baseUrl'] ?? "http://localhost:8000",
+    baseUrl: dotenv.env['BASE_URL'] ?? "http://localhost:8000",
   ));
 
   Future<Response> searchArtwork(String query) async {

--- a/lib/ui/components/artwork_result_list.dart
+++ b/lib/ui/components/artwork_result_list.dart
@@ -189,50 +189,456 @@ class ArtworkResultsList extends StatelessWidget {
       ),
     );
 
-    return frontendUrl != null && frontendUrl.isNotEmpty
-        ? GestureDetector(
-            onTap: () async {
-              final open = await showDialog<bool>(
-                context: context,
-                builder: (context) => AlertDialog(
-                  title: const Text('Do you want to open this link?'),
-                  content: Text(frontendUrl),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(false),
-                      child: const Text('Cancel'),
-                    ),
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(true),
-                      child: const Text('Open'),
-                    ),
-                  ],
+    // Make all cards tappable to show details
+    return GestureDetector(
+      onTap: () {
+        // Find the full item data to show all available information
+        final index = artworks.indexWhere((item) {
+          try {
+            final itemTitle = ((item["titles"] as List?)?.isNotEmpty == true)
+                ? item["titles"][0]["title"]?.toString() ?? "Untitled"
+                : "Untitled";
+            final itemArtist = (item["artist"] as List?)?.isNotEmpty == true
+                ? item["artist"][0] ?? "Unknown"
+                : "Unknown";
+            return itemTitle == title && itemArtist == artist;
+          } catch (e) {
+            return false;
+          }
+        });
+
+        if (index >= 0) {
+          // Use the full item data from the artworks list
+          _showExhibitDetails(context, artworks[index]);
+        } else {
+          // Fallback to basic data if we can't find the full item
+          _showExhibitDetails(context, {
+            "titles": [
+              {"title": title}
+            ],
+            "artist": [artist],
+            "image_thumbnail": thumbnail,
+            "frontend_url": frontendUrl,
+            "current_location_name": location,
+          });
+        }
+      },
+      child: Stack(
+        children: [
+          card,
+          if (hasLink)
+            Positioned(
+              top: 8,
+              right: 8,
+              child: Container(
+                padding: const EdgeInsets.all(4),
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.8),
+                  borderRadius: BorderRadius.circular(12),
                 ),
-              );
-              if (open == true) launchUrl(Uri.parse(frontendUrl));
-            },
-            child: Stack(
-              children: [
-                card,
-                Positioned(
-                  top: 8,
-                  right: 8,
-                  child: Container(
-                    padding: const EdgeInsets.all(4),
+                child: Icon(
+                  Icons.info_outline,
+                  size: 16,
+                  color: Colors.orange.shade800,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  // Helper method to build a detail row
+  Widget _buildDetailRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 100,
+            child: Text(
+              label,
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.orange.shade800,
+                fontSize: 14,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(fontSize: 14),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Helper method to build a colors section with color circles
+  Widget _buildColorsSection(String label, List<String> colorStrings) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Colors.orange.shade800,
+              fontSize: 14,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: colorStrings.map((colorString) {
+              // Convert the color string to a Color object
+              Color displayColor = _parseColorString(colorString);
+
+              // Create a row with color circle and text
+              return Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Color circle
+                  Container(
+                    width: 16,
+                    height: 16,
                     decoration: BoxDecoration(
-                      color: Colors.white.withValues(alpha: 0.8),
-                      borderRadius: BorderRadius.circular(12),
+                      color: displayColor,
+                      shape: BoxShape.circle,
+                      border:
+                          Border.all(color: Colors.grey.shade300, width: 0.5),
                     ),
-                    child: Icon(
-                      Icons.open_in_new,
-                      size: 16,
-                      color: Colors.orange.shade800,
+                  ),
+                  const SizedBox(width: 4),
+                  // Color name
+                  Text(
+                    colorString,
+                    style: const TextStyle(fontSize: 12),
+                  ),
+                ],
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Helper method to parse color strings
+  Color _parseColorString(String colorString) {
+    try {
+      // Handle hex colors with # prefix
+      if (colorString.startsWith('#')) {
+        String hex = colorString.substring(1);
+        if (hex.length == 6) {
+          return Color(int.parse(hex, radix: 16) | 0xFF000000);
+        }
+      }
+
+      // Use a hash-based color for other strings
+      return Color((colorString.hashCode & 0xFFFFFF) | 0xFF000000);
+    } catch (e) {
+      // Default fallback color
+      return Colors.grey;
+    }
+  }
+
+  // Helper method to extract values from the JSON response with error handling
+  String _extractValue(dynamic item, String key) {
+    try {
+      if (item == null || item[key] == null) return "Unknown";
+
+      if (item[key] is List) {
+        final list = item[key] as List;
+        if (list.isEmpty) return "Unknown";
+        return list[0].toString();
+      }
+
+      return item[key].toString();
+    } catch (e) {
+      // Return a default value if there's an error
+      return "Unknown";
+    }
+  }
+
+  // Helper method to extract a list of values with error handling
+  List<String> _extractListValues(dynamic item, String key) {
+    try {
+      if (item == null || item[key] == null) return [];
+
+      if (item[key] is List) {
+        final list = item[key] as List;
+        return list.map((value) => value.toString()).toList();
+      }
+
+      return [];
+    } catch (e) {
+      // Return an empty list if there's an error
+      return [];
+    }
+  }
+
+  void _showExhibitDetails(BuildContext context, dynamic exhibit) {
+    try {
+      // Extract all the relevant information with null safety
+      String title = "Untitled";
+      try {
+        final titles = exhibit["titles"] as List?;
+        title = titles?.isNotEmpty == true
+            ? titles![0]["title"]?.toString() ?? "Untitled"
+            : "Untitled";
+      } catch (e) {
+        // Use default title if there's an error
+      }
+
+      String artist = "Unknown";
+      try {
+        artist = (exhibit["artist"] as List?)?.isNotEmpty == true
+            ? exhibit["artist"][0] ?? "Unknown"
+            : "Unknown";
+      } catch (e) {
+        // Use default artist if there's an error
+      }
+
+      final String? thumbnail = exhibit["image_thumbnail"];
+      final location = exhibit["current_location_name"] ?? "Not on display";
+
+      // Extract additional information - these will return defaults if fields don't exist
+      final dating = _extractValue(exhibit, "production_date");
+      final materials = _extractListValues(exhibit, "materials");
+      final techniques = _extractListValues(exhibit, "techniques");
+      final colors = _extractListValues(exhibit, "colors");
+      final dimensions = _extractListValues(exhibit, "dimensions");
+      final description = _extractValue(exhibit, "content_description");
+
+      showDialog(
+        context: context,
+        builder: (context) => Dialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Container(
+            constraints: BoxConstraints(
+              maxWidth: MediaQuery.of(context).size.width * 0.9,
+              maxHeight: MediaQuery.of(context).size.height * 0.8,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Header with image
+                if (thumbnail != null && thumbnail.isNotEmpty)
+                  ClipRRect(
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(16),
+                      topRight: Radius.circular(16),
+                    ),
+                    child: SizedBox(
+                      height: 200,
+                      child: Stack(
+                        fit: StackFit.expand,
+                        children: [
+                          Image.network(
+                            thumbnail,
+                            fit: BoxFit.cover,
+                            errorBuilder: (context, error, stackTrace) =>
+                                Center(
+                              child: Icon(Icons.broken_image,
+                                  size: 40, color: Colors.grey.shade400),
+                            ),
+                          ),
+                          // Gradient overlay for better text readability
+                          Positioned(
+                            bottom: 0,
+                            left: 0,
+                            right: 0,
+                            child: Container(
+                              height: 60,
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.topCenter,
+                                  end: Alignment.bottomCenter,
+                                  colors: [
+                                    Colors.transparent,
+                                    Colors.black.withOpacity(0.7),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                          // Title and artist on the image
+                          Positioned(
+                            bottom: 8,
+                            left: 16,
+                            right: 16,
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  title,
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 18,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                                Text(
+                                  artist == 'Ubekendt' ? 'Unknown' : artist,
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 14,
+                                  ),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ],
+                            ),
+                          ),
+                          // Close button
+                          Positioned(
+                            top: 8,
+                            right: 8,
+                            child: GestureDetector(
+                              onTap: () => Navigator.of(context).pop(),
+                              child: Container(
+                                padding: const EdgeInsets.all(4),
+                                decoration: BoxDecoration(
+                                  color: Colors.black.withValues(alpha: 0.5),
+                                  shape: BoxShape.circle,
+                                ),
+                                child: const Icon(
+                                  Icons.close,
+                                  color: Colors.white,
+                                  size: 20,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+
+                // Details section
+                Flexible(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (thumbnail == null || thumbnail.isEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 16),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  title,
+                                  style: TextStyle(
+                                    fontSize: 18,
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.orange.shade800,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  artist == 'Ubekendt' ? 'Unknown' : artist,
+                                  style: const TextStyle(
+                                    fontSize: 16,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+
+                        // Location
+                        _buildDetailRow("Location", location),
+
+                        // Dating
+                        if (dating != "Unknown")
+                          _buildDetailRow("Dating", dating),
+
+                        // Materials
+                        if (materials.isNotEmpty)
+                          _buildDetailRow("Materials", materials.join(", ")),
+
+                        // Techniques
+                        if (techniques.isNotEmpty)
+                          _buildDetailRow("Techniques", techniques.join(", ")),
+
+                        // Dimensions
+                        if (dimensions.isNotEmpty)
+                          _buildDetailRow("Dimensions", dimensions.join(", ")),
+
+                        // Colors
+                        if (colors.isNotEmpty)
+                          _buildColorsSection("Colors", colors),
+
+                        // Description
+                        if (description != "Unknown" && description.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 16),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  "Description",
+                                  style: TextStyle(
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.orange.shade800,
+                                    fontSize: 16,
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                Text(
+                                  description,
+                                  style: const TextStyle(fontSize: 14),
+                                ),
+                              ],
+                            ),
+                          ),
+
+                        // Link to more info - with null safety
+                        if (exhibit["frontend_url"] != null &&
+                            exhibit["frontend_url"].toString().isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 16),
+                            child: ElevatedButton.icon(
+                              onPressed: () {
+                                try {
+                                  launchUrl(Uri.parse(exhibit["frontend_url"]));
+                                } catch (e) {
+                                  // Handle URL launch error silently
+                                }
+                              },
+                              icon: const Icon(Icons.open_in_new),
+                              label: const Text("View on Website"),
+                              style: ElevatedButton.styleFrom(
+                                foregroundColor: Colors.white,
+                                backgroundColor: Colors.orange.shade800,
+                              ),
+                            ),
+                          ),
+                      ],
                     ),
                   ),
                 ),
               ],
             ),
-          )
-        : card;
+          ),
+        ),
+      );
+    } catch (e) {
+      // Handle any errors that might occur during dialog creation
+      print("Error showing exhibit details: $e");
+    }
   }
 }

--- a/lib/ui/components/artwork_result_list.dart
+++ b/lib/ui/components/artwork_result_list.dart
@@ -1,20 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// A widget that displays a list of artworks with infinite scrolling.
 /// __[artworks]__ is the list of artworks to display.
-/// 
+///
 /// __[isLoadingMore]__ indicates whether more artworks are being loaded.
-/// 
+///
 /// __[hasMore]__ indicates whether there are more artworks to load.
-/// 
+///
 /// __[loadMore]__ is a callback function to load more artworks when the user scrolls to the bottom of the list.
-/// 
+///
 /// The widget uses a [NotificationListener] to detect when the user has scrolled to the bottom of the list.
 /// When the user scrolls to the bottom, it calls the [loadMore] function to load more artworks.
 ///
 /// If there are no artworks to display, it shows a message indicating that no results were found.
-/// 
-/// Each artwork is displayed in a [Card] widget with a [ListTile] that shows the title and location of the artwork.
+///
+/// Each artwork is displayed in a styled card similar to the PolygonInfoPanel exhibit cards.
 class ArtworkResultsList extends StatelessWidget {
   final List<dynamic> artworks;
   final bool isLoadingMore;
@@ -50,16 +51,188 @@ class ArtworkResultsList extends StatelessWidget {
           itemBuilder: (context, index) {
             final item = artworks[index];
             final titles = item["titles"] as List<dynamic>;
-            final titleString = titles[0]["title"].toString();
+            final titleString = titles.isNotEmpty
+                ? titles[0]["title"]?.toString() ?? "Untitled"
+                : "Untitled";
+            final artist = (item["artist"] as List?)?.isNotEmpty == true
+                ? item["artist"][0] ?? "Unknown"
+                : "Unknown";
+            final String? thumbnail = item["image_thumbnail"];
+            final String? frontendUrl = item["frontend_url"];
             final location = item["current_location_name"] ?? "Not on display";
 
-            return Card(
-              child: ListTile(
-                title: Text(titleString),
-                subtitle: Text("Room: $location"),
+            return Padding(
+              padding:
+                  const EdgeInsets.symmetric(vertical: 6.0, horizontal: 8.0),
+              child: _buildExhibitCard(
+                context,
+                artist,
+                titleString,
+                thumbnail,
+                frontendUrl,
+                location,
               ),
             );
           },
         ));
+  }
+
+  Widget _buildExhibitCard(BuildContext context, String artist, String title,
+      [String? thumbnail, String? frontendUrl, String? location]) {
+    final bool hasLink = frontendUrl != null && frontendUrl.isNotEmpty;
+    final double cardHeight = 180.0; // height
+
+    final card = Card(
+      elevation: hasLink ? 4.0 : 3.0,
+      clipBehavior:
+          Clip.antiAlias, // Ensures image doesn't overflow rounded corners
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12.0),
+        side: BorderSide(
+          color: hasLink ? Colors.orange.shade300 : Colors.grey.shade300,
+          width: hasLink ? 1.0 : 0.5,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Image section - always include a container for consistent sizing
+          SizedBox(
+            height: cardHeight * 0.6, // 60% of card height for image
+            width: double.infinity,
+            child: thumbnail != null && thumbnail.isNotEmpty
+                ? Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      Image.network(
+                        thumbnail,
+                        fit: BoxFit.cover,
+                        errorBuilder: (context, error, stackTrace) => Center(
+                          child: Icon(Icons.broken_image,
+                              size: 40, color: Colors.grey.shade400),
+                        ),
+                      ),
+                      // Gradient overlay for better text readability if needed
+                      Positioned(
+                        bottom: 0,
+                        left: 0,
+                        right: 0,
+                        child: Container(
+                          height: 30,
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              begin: Alignment.topCenter,
+                              end: Alignment.bottomCenter,
+                              colors: [
+                                Colors.transparent,
+                                Colors.black.withValues(alpha: 0.3),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  )
+                : Container(
+                    color: Colors.grey.shade200,
+                    child: Center(
+                      child: Icon(
+                        Icons.image_not_supported,
+                        size: 40,
+                        color: Colors.grey.shade400,
+                      ),
+                    ),
+                  ),
+          ),
+
+          // Text section
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  artist == 'Ubekendt' ? 'Unknown' : artist,
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.orange.shade800,
+                    fontSize: 16,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  title,
+                  style: const TextStyle(fontSize: 14),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (location != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4.0),
+                    child: Text(
+                      "Room: $location",
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Colors.grey.shade700,
+                        fontStyle: FontStyle.italic,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+
+    return frontendUrl != null && frontendUrl.isNotEmpty
+        ? GestureDetector(
+            onTap: () async {
+              final open = await showDialog<bool>(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('Do you want to open this link?'),
+                  content: Text(frontendUrl),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      child: const Text('Cancel'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(true),
+                      child: const Text('Open'),
+                    ),
+                  ],
+                ),
+              );
+              if (open == true) launchUrl(Uri.parse(frontendUrl));
+            },
+            child: Stack(
+              children: [
+                card,
+                Positioned(
+                  top: 8,
+                  right: 8,
+                  child: Container(
+                    padding: const EdgeInsets.all(4),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.8),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Icon(
+                      Icons.open_in_new,
+                      size: 16,
+                      color: Colors.orange.shade800,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          )
+        : card;
   }
 }

--- a/lib/ui/components/artwork_result_list.dart
+++ b/lib/ui/components/artwork_result_list.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:indoor_crowded_regions_frontend/ui/components/error_toast.dart';
+import 'exhibit_card.dart';
+import 'exhibit_detail_dialog.dart';
 
 /// A widget that displays a list of artworks with infinite scrolling.
 /// __[artworks]__ is the list of artworks to display.
@@ -17,11 +19,19 @@ import 'package:url_launcher/url_launcher.dart';
 ///
 /// Each artwork is displayed in a styled card similar to the PolygonInfoPanel exhibit cards.
 class ArtworkResultsList extends StatelessWidget {
+  /// The list of artworks to display
   final List<dynamic> artworks;
+
+  /// Whether more artworks are being loaded
   final bool isLoadingMore;
+
+  /// Whether there are more artworks to load
   final bool hasMore;
+
+  /// Callback function to load more artworks
   final Function() loadMore;
 
+  /// Constructor for the artwork results list
   const ArtworkResultsList({
     super.key,
     required this.artworks,
@@ -33,612 +43,56 @@ class ArtworkResultsList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (artworks.isEmpty) {
-      return const Center(child: Text("No results found"));
-    }
-
-    return NotificationListener(
-        onNotification: (ScrollNotification scrollInfo) {
-          if (!isLoadingMore &&
-              hasMore &&
-              scrollInfo.metrics.pixels >=
-                  scrollInfo.metrics.maxScrollExtent - 200) {
-            loadMore();
-          }
-          return false;
-        },
-        child: ListView.builder(
-          itemCount: artworks.length,
-          itemBuilder: (context, index) {
-            final item = artworks[index];
-            final titles = item["titles"] as List<dynamic>;
-            final titleString = titles.isNotEmpty
-                ? titles[0]["title"]?.toString() ?? "Untitled"
-                : "Untitled";
-            final artist = (item["artist"] as List?)?.isNotEmpty == true
-                ? item["artist"][0] ?? "Unknown"
-                : "Unknown";
-            final String? thumbnail = item["image_thumbnail"];
-            final String? frontendUrl = item["frontend_url"];
-            final location = item["current_location_name"] ?? "Not on display";
-
-            return Padding(
-              padding:
-                  const EdgeInsets.symmetric(vertical: 6.0, horizontal: 8.0),
-              child: _buildExhibitCard(
-                context,
-                artist,
-                titleString,
-                thumbnail,
-                frontendUrl,
-                location,
-              ),
-            );
-          },
-        ));
-  }
-
-  Widget _buildExhibitCard(BuildContext context, String artist, String title,
-      [String? thumbnail, String? frontendUrl, String? location]) {
-    final bool hasLink = frontendUrl != null && frontendUrl.isNotEmpty;
-    final double cardHeight = 180.0; // height
-
-    final card = Card(
-      elevation: hasLink ? 4.0 : 3.0,
-      clipBehavior:
-          Clip.antiAlias, // Ensures image doesn't overflow rounded corners
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12.0),
-        side: BorderSide(
-          color: hasLink ? Colors.orange.shade300 : Colors.grey.shade300,
-          width: hasLink ? 1.0 : 0.5,
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Image section - always include a container for consistent sizing
-          SizedBox(
-            height: cardHeight * 0.6, // 60% of card height for image
-            width: double.infinity,
-            child: thumbnail != null && thumbnail.isNotEmpty
-                ? Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      Image.network(
-                        thumbnail,
-                        fit: BoxFit.cover,
-                        errorBuilder: (context, error, stackTrace) => Center(
-                          child: Icon(Icons.broken_image,
-                              size: 40, color: Colors.grey.shade400),
-                        ),
-                      ),
-                      // Gradient overlay for better text readability if needed
-                      Positioned(
-                        bottom: 0,
-                        left: 0,
-                        right: 0,
-                        child: Container(
-                          height: 30,
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              begin: Alignment.topCenter,
-                              end: Alignment.bottomCenter,
-                              colors: [
-                                Colors.transparent,
-                                Colors.black.withValues(alpha: 0.3),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  )
-                : Container(
-                    color: Colors.grey.shade200,
-                    child: Center(
-                      child: Icon(
-                        Icons.image_not_supported,
-                        size: 40,
-                        color: Colors.grey.shade400,
-                      ),
-                    ),
-                  ),
-          ),
-
-          // Text section
-          Padding(
-            padding: const EdgeInsets.all(12.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  artist == 'Ubekendt' ? 'Unknown' : artist,
-                  style: TextStyle(
-                    fontWeight: FontWeight.bold,
-                    color: Colors.orange.shade800,
-                    fontSize: 16,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  title,
-                  style: const TextStyle(fontSize: 14),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                if (location != null)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4.0),
-                    child: Text(
-                      "Room: $location",
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: Colors.grey.shade700,
-                        fontStyle: FontStyle.italic,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-
-    // Make all cards tappable to show details
-    return GestureDetector(
-      onTap: () {
-        // Find the full item data to show all available information
-        final index = artworks.indexWhere((item) {
-          try {
-            final itemTitle = ((item["titles"] as List?)?.isNotEmpty == true)
-                ? item["titles"][0]["title"]?.toString() ?? "Untitled"
-                : "Untitled";
-            final itemArtist = (item["artist"] as List?)?.isNotEmpty == true
-                ? item["artist"][0] ?? "Unknown"
-                : "Unknown";
-            return itemTitle == title && itemArtist == artist;
-          } catch (e) {
-            return false;
-          }
-        });
-
-        if (index >= 0) {
-          // Use the full item data from the artworks list
-          _showExhibitDetails(context, artworks[index]);
-        } else {
-          // Fallback to basic data if we can't find the full item
-          _showExhibitDetails(context, {
-            "titles": [
-              {"title": title}
-            ],
-            "artist": [artist],
-            "image_thumbnail": thumbnail,
-            "frontend_url": frontendUrl,
-            "current_location_name": location,
-          });
-        }
-      },
-      child: Stack(
-        children: [
-          card,
-          if (hasLink)
-            Positioned(
-              top: 8,
-              right: 8,
-              child: Container(
-                padding: const EdgeInsets.all(4),
-                decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.8),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Icon(
-                  Icons.info_outline,
-                  size: 16,
-                  color: Colors.orange.shade800,
-                ),
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-
-  // Helper method to build a detail row
-  Widget _buildDetailRow(String label, String value) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: 100,
-            child: Text(
-              label,
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                color: Colors.orange.shade800,
-                fontSize: 14,
-              ),
-            ),
-          ),
-          Expanded(
-            child: Text(
-              value,
-              style: const TextStyle(fontSize: 14),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  // Helper method to build a colors section with color circles
-  Widget _buildColorsSection(String label, List<String> colorStrings) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label,
-            style: TextStyle(
-              fontWeight: FontWeight.bold,
-              color: Colors.orange.shade800,
-              fontSize: 14,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: colorStrings.map((colorString) {
-              // Convert the color string to a Color object
-              Color displayColor = _parseColorString(colorString);
-
-              // Create a row with color circle and text
-              return Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // Color circle
-                  Container(
-                    width: 16,
-                    height: 16,
-                    decoration: BoxDecoration(
-                      color: displayColor,
-                      shape: BoxShape.circle,
-                      border:
-                          Border.all(color: Colors.grey.shade300, width: 0.5),
-                    ),
-                  ),
-                  const SizedBox(width: 4),
-                  // Color name
-                  Text(
-                    colorString,
-                    style: const TextStyle(fontSize: 12),
-                  ),
-                ],
-              );
-            }).toList(),
-          ),
-        ],
-      ),
-    );
-  }
-
-  // Helper method to parse color strings
-  Color _parseColorString(String colorString) {
-    try {
-      // Handle hex colors with # prefix
-      if (colorString.startsWith('#')) {
-        String hex = colorString.substring(1);
-        if (hex.length == 6) {
-          return Color(int.parse(hex, radix: 16) | 0xFF000000);
-        }
-      }
-
-      // Use a hash-based color for other strings
-      return Color((colorString.hashCode & 0xFFFFFF) | 0xFF000000);
-    } catch (e) {
-      // Default fallback color
-      return Colors.grey;
-    }
-  }
-
-  // Helper method to extract values from the JSON response with error handling
-  String _extractValue(dynamic item, String key) {
-    try {
-      if (item == null || item[key] == null) return "Unknown";
-
-      if (item[key] is List) {
-        final list = item[key] as List;
-        if (list.isEmpty) return "Unknown";
-        return list[0].toString();
-      }
-
-      return item[key].toString();
-    } catch (e) {
-      // Return a default value if there's an error
-      return "Unknown";
-    }
-  }
-
-  // Helper method to extract a list of values with error handling
-  List<String> _extractListValues(dynamic item, String key) {
-    try {
-      if (item == null || item[key] == null) return [];
-
-      if (item[key] is List) {
-        final list = item[key] as List;
-        return list.map((value) => value.toString()).toList();
-      }
-
-      return [];
-    } catch (e) {
-      // Return an empty list if there's an error
-      return [];
-    }
-  }
-
-  void _showExhibitDetails(BuildContext context, dynamic exhibit) {
-    try {
-      // Extract all the relevant information with null safety
-      String title = "Untitled";
-      try {
-        final titles = exhibit["titles"] as List?;
-        title = titles?.isNotEmpty == true
-            ? titles![0]["title"]?.toString() ?? "Untitled"
-            : "Untitled";
-      } catch (e) {
-        // Use default title if there's an error
-      }
-
-      String artist = "Unknown";
-      try {
-        artist = (exhibit["artist"] as List?)?.isNotEmpty == true
-            ? exhibit["artist"][0] ?? "Unknown"
-            : "Unknown";
-      } catch (e) {
-        // Use default artist if there's an error
-      }
-
-      final String? thumbnail = exhibit["image_thumbnail"];
-      final location = exhibit["current_location_name"] ?? "Not on display";
-
-      // Extract additional information - these will return defaults if fields don't exist
-      final dating = _extractValue(exhibit, "production_date");
-      final materials = _extractListValues(exhibit, "materials");
-      final techniques = _extractListValues(exhibit, "techniques");
-      final colors = _extractListValues(exhibit, "colors");
-      final dimensions = _extractListValues(exhibit, "dimensions");
-      final description = _extractValue(exhibit, "content_description");
-
-      showDialog(
-        context: context,
-        builder: (context) => Dialog(
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-          child: Container(
-            constraints: BoxConstraints(
-              maxWidth: MediaQuery.of(context).size.width * 0.9,
-              maxHeight: MediaQuery.of(context).size.height * 0.8,
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Header with image
-                if (thumbnail != null && thumbnail.isNotEmpty)
-                  ClipRRect(
-                    borderRadius: const BorderRadius.only(
-                      topLeft: Radius.circular(16),
-                      topRight: Radius.circular(16),
-                    ),
-                    child: SizedBox(
-                      height: 200,
-                      child: Stack(
-                        fit: StackFit.expand,
-                        children: [
-                          Image.network(
-                            thumbnail,
-                            fit: BoxFit.cover,
-                            errorBuilder: (context, error, stackTrace) =>
-                                Center(
-                              child: Icon(Icons.broken_image,
-                                  size: 40, color: Colors.grey.shade400),
-                            ),
-                          ),
-                          // Gradient overlay for better text readability
-                          Positioned(
-                            bottom: 0,
-                            left: 0,
-                            right: 0,
-                            child: Container(
-                              height: 60,
-                              decoration: BoxDecoration(
-                                gradient: LinearGradient(
-                                  begin: Alignment.topCenter,
-                                  end: Alignment.bottomCenter,
-                                  colors: [
-                                    Colors.transparent,
-                                    Colors.black.withOpacity(0.7),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          ),
-                          // Title and artist on the image
-                          Positioned(
-                            bottom: 8,
-                            left: 16,
-                            right: 16,
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  title,
-                                  style: const TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                  maxLines: 2,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                                Text(
-                                  artist == 'Ubekendt' ? 'Unknown' : artist,
-                                  style: const TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 14,
-                                  ),
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                              ],
-                            ),
-                          ),
-                          // Close button
-                          Positioned(
-                            top: 8,
-                            right: 8,
-                            child: GestureDetector(
-                              onTap: () => Navigator.of(context).pop(),
-                              child: Container(
-                                padding: const EdgeInsets.all(4),
-                                decoration: BoxDecoration(
-                                  color: Colors.black.withValues(alpha: 0.5),
-                                  shape: BoxShape.circle,
-                                ),
-                                child: const Icon(
-                                  Icons.close,
-                                  color: Colors.white,
-                                  size: 20,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-
-                // Details section
-                Flexible(
-                  child: SingleChildScrollView(
-                    padding: const EdgeInsets.all(16),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        if (thumbnail == null || thumbnail.isEmpty)
-                          Padding(
-                            padding: const EdgeInsets.only(bottom: 16),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  title,
-                                  style: TextStyle(
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.bold,
-                                    color: Colors.orange.shade800,
-                                  ),
-                                ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  artist == 'Ubekendt' ? 'Unknown' : artist,
-                                  style: const TextStyle(
-                                    fontSize: 16,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-
-                        // Location
-                        _buildDetailRow("Location", location),
-
-                        // Dating
-                        if (dating != "Unknown")
-                          _buildDetailRow("Dating", dating),
-
-                        // Materials
-                        if (materials.isNotEmpty)
-                          _buildDetailRow("Materials", materials.join(", ")),
-
-                        // Techniques
-                        if (techniques.isNotEmpty)
-                          _buildDetailRow("Techniques", techniques.join(", ")),
-
-                        // Dimensions
-                        if (dimensions.isNotEmpty)
-                          _buildDetailRow("Dimensions", dimensions.join(", ")),
-
-                        // Colors
-                        if (colors.isNotEmpty)
-                          _buildColorsSection("Colors", colors),
-
-                        // Description
-                        if (description != "Unknown" && description.isNotEmpty)
-                          Padding(
-                            padding: const EdgeInsets.only(top: 16),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  "Description",
-                                  style: TextStyle(
-                                    fontWeight: FontWeight.bold,
-                                    color: Colors.orange.shade800,
-                                    fontSize: 16,
-                                  ),
-                                ),
-                                const SizedBox(height: 8),
-                                Text(
-                                  description,
-                                  style: const TextStyle(fontSize: 14),
-                                ),
-                              ],
-                            ),
-                          ),
-
-                        // Link to more info - with null safety
-                        if (exhibit["frontend_url"] != null &&
-                            exhibit["frontend_url"].toString().isNotEmpty)
-                          Padding(
-                            padding: const EdgeInsets.only(top: 16),
-                            child: ElevatedButton.icon(
-                              onPressed: () {
-                                try {
-                                  launchUrl(Uri.parse(exhibit["frontend_url"]));
-                                } catch (e) {
-                                  // Handle URL launch error silently
-                                }
-                              },
-                              icon: const Icon(Icons.open_in_new),
-                              label: const Text("View on Website"),
-                              style: ElevatedButton.styleFrom(
-                                foregroundColor: Colors.white,
-                                backgroundColor: Colors.orange.shade800,
-                              ),
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
+      return const Center(
+        child: Text(
+          "No results found",
+          style: TextStyle(color: Colors.white70), // Light text for dark mode
         ),
       );
+    }
+
+    return NotificationListener<ScrollNotification>(
+      onNotification: (ScrollNotification scrollInfo) {
+        if (!isLoadingMore &&
+            hasMore &&
+            scrollInfo.metrics.pixels >=
+                scrollInfo.metrics.maxScrollExtent - 200) {
+          loadMore();
+        }
+        return false;
+      },
+      child: ListView.builder(
+        itemCount: artworks.length,
+        itemBuilder: (context, index) {
+          final item = artworks[index];
+          final String? frontendUrl = item["frontend_url"];
+          final bool hasLink = frontendUrl != null && frontendUrl.isNotEmpty;
+
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 6.0, horizontal: 8.0),
+            child: ExhibitCard(
+              exhibit: item,
+              hasLink: hasLink,
+              onTap: () => _showExhibitDetails(context, index),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  /// Show the exhibit details dialog
+  void _showExhibitDetails(BuildContext context, int index) {
+    // Find the full item data to show all available information
+    try {
+      final selectedItem = artworks[index];
+      // Show the dialog with the full item data
+      showDialog(
+        context: context,
+        builder: (context) => ExhibitDetailDialog(exhibit: selectedItem),
+      );
     } catch (e) {
-      // Handle any errors that might occur during dialog creation
-      print("Error showing exhibit details: $e");
+      ErrorToast.show("Could not create dialog screen.");
     }
   }
 }

--- a/lib/ui/components/artwork_result_list.dart
+++ b/lib/ui/components/artwork_result_list.dart
@@ -17,7 +17,8 @@ import 'exhibit_detail_dialog.dart';
 ///
 /// If there are no artworks to display, it shows a message indicating that no results were found.
 ///
-/// Each artwork is displayed in a styled card similar to the PolygonInfoPanel exhibit cards.
+/// Each artwork is displayed in an [ExhibitCard].
+
 class ArtworkResultsList extends StatelessWidget {
   /// The list of artworks to display
   final List<dynamic> artworks;

--- a/lib/ui/components/color_section.dart
+++ b/lib/ui/components/color_section.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import '../../utils/color_utils.dart';
+
+/// A widget that displays a section with color circles and their names
+class ColorSection extends StatelessWidget {
+  /// The label for the section
+  final String label;
+
+  /// The list of color strings to display
+  final List<String> colors;
+
+  /// Constructor for the color section
+  const ColorSection({
+    super.key,
+    required this.label,
+    required this.colors,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Colors.orange.shade500, // Brighter orange for dark mode
+              fontSize: 14,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: colors.map((colorString) {
+              Color displayColor;
+              try {
+                displayColor = ColorUtils.parseColorString(colorString);
+              } catch (e) {
+                displayColor = Colors.grey; // fallback if parsing fails
+              }
+              return Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                decoration: BoxDecoration(
+                  color: const Color(
+                      0xFF2D2D2D), // Dark background for color chips
+                  border: Border.all(
+                      color: Colors.grey.shade600,
+                      width: 0.5), // Darker border for visibility
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 16,
+                      height: 16,
+                      decoration: BoxDecoration(
+                        color: displayColor,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Flexible(
+                      child: Text(
+                        colorString,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: Colors.white70, // Light text for dark mode
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/components/exhibit_card.dart
+++ b/lib/ui/components/exhibit_card.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import '../../utils/data_extractor.dart';
+
+/// A card widget that displays an exhibit item
+class ExhibitCard extends StatelessWidget {
+  /// The exhibit data to display
+  final dynamic exhibit;
+
+  /// Callback when the card is tapped
+  final VoidCallback onTap;
+
+  /// Whether the card has a link
+  final bool hasLink;
+
+  /// Constructor for the exhibit card
+  const ExhibitCard({
+    super.key,
+    required this.exhibit,
+    required this.onTap,
+    this.hasLink = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final String artist = DataExtractor.extractArtist(exhibit);
+    final String title = DataExtractor.extractTitle(exhibit);
+    final String? thumbnail = exhibit["image_thumbnail"];
+    final String location = DataExtractor.extractLocation(exhibit);
+    const double cardHeight = 180.0;
+
+    final card = Card(
+      elevation: hasLink ? 4.0 : 3.0,
+      clipBehavior: Clip.antiAlias,
+      color: const Color(0xFF2D2D2D), // Dark background for card
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12.0),
+        side: BorderSide(
+          color: hasLink ? Colors.orange.shade400 : Colors.grey.shade600,
+          width: hasLink ? 1.0 : 0.5,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Image section
+          SizedBox(
+            height: cardHeight * 0.6, // 60% of card height for image
+            width: double.infinity,
+            child: thumbnail != null && thumbnail.isNotEmpty
+                ? Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      Image.network(
+                        thumbnail,
+                        fit: BoxFit.cover,
+                        errorBuilder: (context, error, stackTrace) => Center(
+                          child: Icon(
+                            Icons.broken_image,
+                            size: 40,
+                            color: Colors.grey.shade400,
+                          ),
+                        ),
+                      ),
+                      // Gradient overlay for better text readability
+                      Positioned(
+                        bottom: 0,
+                        left: 0,
+                        right: 0,
+                        child: Container(
+                          height: 30,
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              begin: Alignment.topCenter,
+                              end: Alignment.bottomCenter,
+                              colors: [
+                                Colors.transparent,
+                                Colors.black.withValues(alpha: 0.3),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  )
+                : Container(
+                    color: const Color(
+                        0xFF1E1E1E), // Darker background for placeholder
+                    child: Center(
+                      child: Icon(
+                        Icons.image_not_supported,
+                        size: 40,
+                        color:
+                            Colors.grey.shade600, // Lighter gray for visibility
+                      ),
+                    ),
+                  ),
+          ),
+
+          // Text section
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  artist == 'Ubekendt' ? 'Unknown' : artist,
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color:
+                        Colors.orange.shade500, // Brighter orange for dark mode
+                    fontSize: 16,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    color: Colors.white70, // Light text for dark mode
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (location.isNotEmpty && location != "Not on display")
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4.0),
+                    child: Text(
+                      "Room: $location",
+                      style: TextStyle(
+                        fontSize: 12,
+                        color:
+                            Colors.grey.shade400, // Lighter gray for visibility
+                        fontStyle: FontStyle.italic,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Stack(
+        children: [
+          card,
+          if (hasLink)
+            Positioned(
+              top: 8,
+              right: 8,
+              child: Container(
+                padding: const EdgeInsets.all(4),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF2D2D2D)
+                      .withValues(alpha: 0.8), // Dark background for icon
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(
+                  Icons.info_outline,
+                  size: 16,
+                  color:
+                      Colors.orange.shade500, // Brighter orange for dark mode
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/components/exhibit_detail_dialog.dart
+++ b/lib/ui/components/exhibit_detail_dialog.dart
@@ -15,15 +15,11 @@ class ExhibitDetailDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final String title =
-        DataExtractor.extractTitle(exhibit) ?? 'No Title Available';
-    final String artist =
-        _formatArtist(DataExtractor.extractArtist(exhibit) ?? 'Unknown');
+    final String title = DataExtractor.extractTitle(exhibit);
+    final String artist = _formatArtist(DataExtractor.extractArtist(exhibit));
     final String? thumbnail = exhibit["image_thumbnail"];
-    final String location =
-        DataExtractor.extractLocation(exhibit) ?? 'Location Not Provided';
-    final String dating =
-        DateFormatter.formatDating(exhibit) ?? 'Dating Not Available';
+    final String location = DataExtractor.extractLocation(exhibit);
+    final String dating = DateFormatter.formatDating(exhibit);
     final List<String> materials =
         DataExtractor.extractListValues(exhibit, "materials");
     final List<String> techniques =
@@ -34,8 +30,7 @@ class ExhibitDetailDialog extends StatelessWidget {
         DimensionFormatter.formatNettoDimensions(exhibit) ??
             'Dimensions Not Available';
     final String description =
-        DataExtractor.extractValue(exhibit, "content_description") ??
-            'Description Not Available';
+        DataExtractor.extractValue(exhibit, "content_description");
     final String? frontendUrl = exhibit["frontend_url"];
 
     return Dialog(
@@ -57,7 +52,7 @@ class ExhibitDetailDialog extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              if (thumbnail != null && thumbnail.isNotEmpty)
+              if (thumbnail != null)
                 _buildHeaderWithImage(context, thumbnail, title, artist),
               Flexible(
                 child: SingleChildScrollView(
@@ -65,7 +60,7 @@ class ExhibitDetailDialog extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      if (thumbnail == null || thumbnail.isEmpty)
+                      if (thumbnail == null)
                         _buildHeaderWithoutImage(title, artist),
                       ExhibitDetailRow(label: "Location", value: location),
                       if (dating != "Unknown")
@@ -83,8 +78,7 @@ class ExhibitDetailDialog extends StatelessWidget {
                         ColorSection(label: "Colors", colors: colors),
                       if (description.isNotEmpty && description != "Unknown")
                         _buildDescriptionSection(description),
-                      if (frontendUrl != null && frontendUrl.isNotEmpty)
-                        _buildLinkButton(frontendUrl),
+                      if (frontendUrl != null) _buildLinkButton(frontendUrl),
                     ],
                   ),
                 ),
@@ -128,7 +122,7 @@ class ExhibitDetailDialog extends StatelessWidget {
                     end: Alignment.bottomCenter,
                     colors: [
                       Colors.transparent,
-                      Colors.black.withOpacity(0.7),
+                      Colors.black.withValues(alpha: 0.7),
                     ],
                   ),
                 ),

--- a/lib/ui/components/exhibit_detail_dialog.dart
+++ b/lib/ui/components/exhibit_detail_dialog.dart
@@ -165,7 +165,7 @@ class ExhibitDetailDialog extends StatelessWidget {
                 child: Container(
                   padding: const EdgeInsets.all(4),
                   decoration: BoxDecoration(
-                    color: Colors.black.withOpacity(0.5),
+                    color: Colors.black.withValues(alpha: 0.5),
                     shape: BoxShape.circle,
                   ),
                   child: const Icon(Icons.close, color: Colors.white, size: 20),

--- a/lib/ui/components/exhibit_detail_dialog.dart
+++ b/lib/ui/components/exhibit_detail_dialog.dart
@@ -1,0 +1,262 @@
+import 'package:flutter/material.dart';
+import 'package:indoor_crowded_regions_frontend/ui/components/error_toast.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../../utils/data_extractor.dart';
+import '../../utils/date_formatter.dart';
+import '../../utils/dimension_formatter.dart';
+import 'exhibit_detail_row.dart';
+import 'color_section.dart';
+
+/// A dialog that displays detailed information about an exhibit
+class ExhibitDetailDialog extends StatelessWidget {
+  final dynamic exhibit;
+
+  const ExhibitDetailDialog({super.key, required this.exhibit});
+
+  @override
+  Widget build(BuildContext context) {
+    final String title =
+        DataExtractor.extractTitle(exhibit) ?? 'No Title Available';
+    final String artist =
+        _formatArtist(DataExtractor.extractArtist(exhibit) ?? 'Unknown');
+    final String? thumbnail = exhibit["image_thumbnail"];
+    final String location =
+        DataExtractor.extractLocation(exhibit) ?? 'Location Not Provided';
+    final String dating =
+        DateFormatter.formatDating(exhibit) ?? 'Dating Not Available';
+    final List<String> materials =
+        DataExtractor.extractListValues(exhibit, "materials");
+    final List<String> techniques =
+        DataExtractor.extractListValues(exhibit, "techniques");
+    final List<String> colors =
+        DataExtractor.extractListValues(exhibit, "colors");
+    final String dimensions =
+        DimensionFormatter.formatNettoDimensions(exhibit) ??
+            'Dimensions Not Available';
+    final String description =
+        DataExtractor.extractValue(exhibit, "content_description") ??
+            'Description Not Available';
+    final String? frontendUrl = exhibit["frontend_url"];
+
+    return Dialog(
+      backgroundColor: const Color(0xFF1E1E1E), // Dark background
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(
+          color: Colors.orange.shade500, // Orange border
+          width: 2, // Border thickness
+        ),
+      ),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.9,
+          maxHeight: MediaQuery.of(context).size.height * 0.9,
+        ),
+        child: IntrinsicHeight(
+          // <-- Automatically adapts to content height
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (thumbnail != null && thumbnail.isNotEmpty)
+                _buildHeaderWithImage(context, thumbnail, title, artist),
+              Flexible(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (thumbnail == null || thumbnail.isEmpty)
+                        _buildHeaderWithoutImage(title, artist),
+                      ExhibitDetailRow(label: "Location", value: location),
+                      if (dating != "Unknown")
+                        ExhibitDetailRow(label: "Dating", value: dating),
+                      if (materials.isNotEmpty)
+                        ExhibitDetailRow(
+                            label: "Materials", value: materials.join(", ")),
+                      if (techniques.isNotEmpty)
+                        ExhibitDetailRow(
+                            label: "Techniques", value: techniques.join(", ")),
+                      if (dimensions.isNotEmpty)
+                        ExhibitDetailRow(
+                            label: "Dimensions", value: dimensions),
+                      if (colors.isNotEmpty)
+                        ColorSection(label: "Colors", colors: colors),
+                      if (description.isNotEmpty && description != "Unknown")
+                        _buildDescriptionSection(description),
+                      if (frontendUrl != null && frontendUrl.isNotEmpty)
+                        _buildLinkButton(frontendUrl),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _formatArtist(String artist) =>
+      artist == 'Ubekendt' ? 'Unknown' : artist;
+
+  Widget _buildHeaderWithImage(
+      BuildContext context, String thumbnail, String title, String artist) {
+    return ClipRRect(
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+      child: SizedBox(
+        height: 200,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            Image.network(
+              thumbnail,
+              fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) => Center(
+                child: Icon(Icons.broken_image,
+                    size: 40, color: Colors.grey.shade400),
+              ),
+            ),
+            Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: Container(
+                height: 60,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      Colors.transparent,
+                      Colors.black.withOpacity(0.7),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            Positioned(
+              bottom: 8,
+              left: 16,
+              right: 16,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    artist,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 14,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            Positioned(
+              top: 8,
+              right: 8,
+              child: GestureDetector(
+                onTap: () => Navigator.of(context).pop(),
+                child: Container(
+                  padding: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withOpacity(0.5),
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(Icons.close, color: Colors.white, size: 20),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeaderWithoutImage(String title, String artist) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              color: Colors.orange.shade500, // Brighter orange for dark mode
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            artist,
+            style: const TextStyle(
+              fontSize: 16,
+              color: Colors.white70, // Light text for dark mode
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDescriptionSection(String description) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            "Description",
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Colors.orange.shade500, // Brighter orange for dark mode
+              fontSize: 16,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            description,
+            style: const TextStyle(
+              fontSize: 14,
+              color: Colors.white70, // Light text for dark mode
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLinkButton(String url) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16),
+      child: ElevatedButton.icon(
+        onPressed: () async {
+          try {
+            await launchUrl(Uri.parse(url));
+          } catch (e) {
+            ErrorToast.show("Failed to access URL");
+          }
+        },
+        icon: const Icon(Icons.open_in_new),
+        label: const Text("View on Website"),
+        style: ElevatedButton.styleFrom(
+          foregroundColor: Colors.white,
+          backgroundColor:
+              Colors.orange.shade500, // Brighter orange for dark mode
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/components/exhibit_detail_dialog.dart
+++ b/lib/ui/components/exhibit_detail_dialog.dart
@@ -44,7 +44,7 @@ class ExhibitDetailDialog extends StatelessWidget {
         borderRadius: BorderRadius.circular(16),
         side: BorderSide(
           color: Colors.orange.shade500, // Orange border
-          width: 2, // Border thickness
+          width: 1, // Border thickness
         ),
       ),
       child: ConstrainedBox(

--- a/lib/ui/components/exhibit_detail_row.dart
+++ b/lib/ui/components/exhibit_detail_row.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+/// A widget that displays a row with a label and a value
+class ExhibitDetailRow extends StatelessWidget {
+  /// The label to display
+  final String label;
+
+  /// The value to display
+  final String value;
+
+  /// Constructor for the exhibit detail row
+  const ExhibitDetailRow({
+    super.key,
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 100,
+            child: Text(
+              label,
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.orange.shade500, // Brighter orange for dark mode
+                fontSize: 14,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(
+                fontSize: 14,
+                color: Colors.white70, // Light text for dark mode
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/components/search_input_bar.dart
+++ b/lib/ui/components/search_input_bar.dart
@@ -29,13 +29,13 @@ class SearchInputBar extends StatelessWidget {
           leading: const Icon(Icons.search,
               color: Color(0xFFFF7D00)), // Brighter orange for dark mode
           hintText: "Search for artworks",
-          backgroundColor: const MaterialStatePropertyAll<Color>(
+          backgroundColor: const WidgetStatePropertyAll<Color>(
               Color(0xFF2D2D2D)), // Dark background for search bar
-          overlayColor: const MaterialStatePropertyAll<Color>(
+          overlayColor: const WidgetStatePropertyAll<Color>(
               Color(0xFF1E1E1E)), // Dark background for overlay
-          textStyle: const MaterialStatePropertyAll<TextStyle>(
+          textStyle: const WidgetStatePropertyAll<TextStyle>(
               TextStyle(color: Colors.white70)), // Light text for dark mode
-          hintStyle: const MaterialStatePropertyAll<TextStyle>(TextStyle(
+          hintStyle: const WidgetStatePropertyAll<TextStyle>(TextStyle(
               color: Color(
                   0xFFBDBDBD))), // Lighter gray for visibility (equivalent to Colors.grey.shade400)
         );

--- a/lib/ui/components/search_input_bar.dart
+++ b/lib/ui/components/search_input_bar.dart
@@ -26,8 +26,18 @@ class SearchInputBar extends StatelessWidget {
           padding: const WidgetStatePropertyAll<EdgeInsets>(
             EdgeInsets.symmetric(horizontal: 16.0),
           ),
-          leading: const Icon(Icons.search),
+          leading: const Icon(Icons.search,
+              color: Color(0xFFFF7D00)), // Brighter orange for dark mode
           hintText: "Search for artworks",
+          backgroundColor: const MaterialStatePropertyAll<Color>(
+              Color(0xFF2D2D2D)), // Dark background for search bar
+          overlayColor: const MaterialStatePropertyAll<Color>(
+              Color(0xFF1E1E1E)), // Dark background for overlay
+          textStyle: const MaterialStatePropertyAll<TextStyle>(
+              TextStyle(color: Colors.white70)), // Light text for dark mode
+          hintStyle: const MaterialStatePropertyAll<TextStyle>(TextStyle(
+              color: Color(
+                  0xFFBDBDBD))), // Lighter gray for visibility (equivalent to Colors.grey.shade400)
         );
       },
       suggestionsBuilder: (context, controller) => [],

--- a/lib/ui/components/search_suggestion_list.dart
+++ b/lib/ui/components/search_suggestion_list.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
 /// A widget that displays a list of search suggestions.
-/// 
+///
 /// __[suggestions]__ is the list of suggestions to display.
-/// 
+///
 /// __[onSelect]__ is a callback function that is called when a suggestion is selected.
-/// 
-/// The widget uses a [ListView] to display the suggestions.Each suggestion 
-/// is displayed in a [ListTile] widget. When a suggestion is selected, 
+///
+/// The widget uses a [ListView] to display the suggestions.Each suggestion
+/// is displayed in a [ListTile] widget. When a suggestion is selected,
 /// it calls the [onSelect] function with the selected suggestion.
 class SearchSuggestionList extends StatelessWidget {
   final List<String> suggestions;
@@ -32,11 +32,12 @@ class SearchSuggestionList extends StatelessWidget {
         child: Container(
           padding: const EdgeInsets.symmetric(vertical: 4.0),
           decoration: BoxDecoration(
-            color: Colors.white,
+            color: const Color(0xFF2D2D2D), // Dark background for suggestions
             borderRadius: BorderRadius.circular(8),
             boxShadow: [
               BoxShadow(
-                color: Colors.black.withAlpha(10),
+                color:
+                    Colors.black.withAlpha(50), // Darker shadow for visibility
                 blurRadius: 8,
                 offset: const Offset(0, 2),
               ),
@@ -53,7 +54,9 @@ class SearchSuggestionList extends StatelessWidget {
               return ListTile(
                 dense: true,
                 visualDensity: VisualDensity.compact,
-                title: Text(truncatedItem),
+                title: Text(truncatedItem,
+                    style: const TextStyle(
+                        color: Colors.white70)), // Light text for dark mode
                 onTap: () => onSelect(item),
               );
             },

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -39,7 +39,7 @@ class HomeScreen extends StatefulWidget {
   const HomeScreen({
     super.key,
     this.loadGraphDataFn,
-    this.skipUserLocation = false,
+    this.skipUserLocation = true,
     this.isTestMode = false,
     this.gatewayService,
   });

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -147,7 +147,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Error loading map data for floor $floor.'),
-            backgroundColor: Colors.redAccent,
+            backgroundColor: Colors.red.shade700, // Darker red for dark mode
           ),
         );
       }
@@ -365,6 +365,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
     return Scaffold(
       key: scaffoldKey,
+      backgroundColor: const Color(0xFF121212), // Dark background for scaffold
       drawer: BurgerDrawer(highlightedCategory: highlightRooms),
       body: Stack(
         children: [

--- a/lib/ui/widgets/burger_drawer.dart
+++ b/lib/ui/widgets/burger_drawer.dart
@@ -4,7 +4,8 @@ import 'exhibits_menu.dart';
 
 class BurgerDrawer extends StatefulWidget {
   final void Function(String category) highlightedCategory;
-  const BurgerDrawer({super.key, this.highlightedCategory = _defaultHighlightedCategory});
+  const BurgerDrawer(
+      {super.key, this.highlightedCategory = _defaultHighlightedCategory});
   static void _defaultHighlightedCategory(String category) {}
   @override
   State<BurgerDrawer> createState() => BurgerDrawerState();
@@ -26,43 +27,72 @@ class BurgerDrawerState extends State<BurgerDrawer> {
   @override
   Widget build(BuildContext context) {
     return Drawer(
+      backgroundColor: const Color(0xFF1E1E1E), // Dark background for drawer
       child: Column(
         children: [
           Expanded(
             child: Center(
-              child: showExhibitsMenu ? ExhibitsMenu(showExhibitsMenu: showExhibitsMenuFunc) :
-              ListView(
-                shrinkWrap: true,
-                children: <Widget>[
-                  ListTile(
-                    leading: const Icon(Icons.wc_rounded),
-                    title: const Text('Bathrooms'),
-                    onTap: () => highlightedCategory("Bathroom"),
-                  ),
-                  ListTile(
-                    leading: const Icon(Icons.shopping_cart_outlined),
-                    title: const Text('Shops'),
-                    onTap: () => ErrorToast.show('Shop is currently not available.'),
-                  ),
-                  ListTile(
-                    leading: const Icon(Icons.food_bank_outlined),
-                    title: const Text('Food'),
-                    onTap: () => highlightedCategory("Cafeteria"),
-                  ),
-                  ListTile(
-                    leading: const Icon(Icons.location_on_outlined),
-                    title: const Text('Exhibits'),
-                    onTap: () => setState(() {
-                      showExhibitsMenu = true;
-                    }),
-                  ),
-                  ListTile(
-                    leading: const Icon(Icons.web),
-                    title: const Text('Website'),
-                    onTap: () => ErrorToast.show('Website is currently not available.'),
-                  ),
-                ],
-              ),
+              child: showExhibitsMenu
+                  ? ExhibitsMenu(showExhibitsMenu: showExhibitsMenuFunc)
+                  : ListView(
+                      shrinkWrap: true,
+                      children: <Widget>[
+                        ListTile(
+                          leading: const Icon(Icons.wc_rounded,
+                              color: Color(
+                                  0xFFFF7D00)), // Brighter orange for dark mode
+                          title: const Text('Bathrooms',
+                              style: TextStyle(
+                                  color: Colors
+                                      .white)), // Light text for dark mode
+                          onTap: () => highlightedCategory("Bathroom"),
+                        ),
+                        ListTile(
+                          leading: const Icon(Icons.shopping_cart_outlined,
+                              color: Color(
+                                  0xFFFF7D00)), // Brighter orange for dark mode
+                          title: const Text('Shops',
+                              style: TextStyle(
+                                  color: Colors
+                                      .white)), // Light text for dark mode
+                          onTap: () => ErrorToast.show(
+                              'Shop is currently not available.'),
+                        ),
+                        ListTile(
+                          leading: const Icon(Icons.food_bank_outlined,
+                              color: Color(
+                                  0xFFFF7D00)), // Brighter orange for dark mode
+                          title: const Text('Food',
+                              style: TextStyle(
+                                  color: Colors
+                                      .white)), // Light text for dark mode
+                          onTap: () => highlightedCategory("Cafeteria"),
+                        ),
+                        ListTile(
+                          leading: const Icon(Icons.location_on_outlined,
+                              color: Color(
+                                  0xFFFF7D00)), // Brighter orange for dark mode
+                          title: const Text('Exhibits',
+                              style: TextStyle(
+                                  color: Colors
+                                      .white)), // Light text for dark mode
+                          onTap: () => setState(() {
+                            showExhibitsMenu = true;
+                          }),
+                        ),
+                        ListTile(
+                          leading: const Icon(Icons.web,
+                              color: Color(
+                                  0xFFFF7D00)), // Brighter orange for dark mode
+                          title: const Text('Website',
+                              style: TextStyle(
+                                  color: Colors
+                                      .white)), // Light text for dark mode
+                          onTap: () => ErrorToast.show(
+                              'Website is currently not available.'),
+                        ),
+                      ],
+                    ),
             ),
           ),
         ],

--- a/lib/ui/widgets/burger_menu.dart
+++ b/lib/ui/widgets/burger_menu.dart
@@ -9,8 +9,9 @@ class BurgerMenu extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: Colors.black.withValues(alpha: 0.3), 
-        borderRadius: BorderRadius.circular(12), 
+        color: const Color(0xFF1E1E1E)
+            .withValues(alpha: 0.8), // Dark background for burger menu
+        borderRadius: BorderRadius.circular(12),
       ),
       child: IconButton(
         icon: const Icon(Icons.menu, size: 40, color: Colors.white),

--- a/lib/ui/widgets/exhibits_menu.dart
+++ b/lib/ui/widgets/exhibits_menu.dart
@@ -133,8 +133,8 @@ class _ExhibitsMenuState extends State<ExhibitsMenu> {
                   const SizedBox(height: 8),
                   // Title for the results section
                   if (artworks.isNotEmpty)
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(8.0, 8.0, 8.0, 4.0),
+                    const Padding(
+                      padding: EdgeInsets.fromLTRB(8.0, 8.0, 8.0, 4.0),
                       child: Align(
                         alignment: Alignment.centerLeft,
                         child: Text(
@@ -142,7 +142,7 @@ class _ExhibitsMenuState extends State<ExhibitsMenu> {
                           style: TextStyle(
                             fontSize: 20,
                             fontWeight: FontWeight.bold,
-                            color: const Color(
+                            color: Color(
                                 0xFFFF7D00), // Brighter orange for dark mode
                           ),
                         ),

--- a/lib/ui/widgets/exhibits_menu.dart
+++ b/lib/ui/widgets/exhibits_menu.dart
@@ -103,37 +103,61 @@ class _ExhibitsMenuState extends State<ExhibitsMenu> {
           onPressed: () => showExhibits(false),
         ),
         title: const Text("Search Exhibits"),
+        backgroundColor: Colors.white,
+        foregroundColor: Colors.orange.shade800,
+        elevation: 2,
       ),
       body: Stack(
         children: <Widget>[
           // Content of the screen, including artworks list
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Column(
-              children: <Widget>[
-                SearchInputBar(
-                  controller: searchTextController,
-                  onTap: () => setState(() {
-                    suggestions = previousSearch;
-                  }),
-                  onSubmit: _performSearch,
-                  onChanged: (value) => setState(() {
-                    suggestions = previousSearch
-                        .where((item) =>
-                            item.toLowerCase().contains(value.toLowerCase()))
-                        .toList();
-                  }),
-                ),
-                Expanded(
+          Container(
+            color: Colors.grey.shade50,
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Column(
+                children: <Widget>[
+                  SearchInputBar(
+                    controller: searchTextController,
+                    onTap: () => setState(() {
+                      suggestions = previousSearch;
+                    }),
+                    onSubmit: _performSearch,
+                    onChanged: (value) => setState(() {
+                      suggestions = previousSearch
+                          .where((item) =>
+                              item.toLowerCase().contains(value.toLowerCase()))
+                          .toList();
+                    }),
+                  ),
+                  const SizedBox(height: 8),
+                  // Title for the results section
+                  if (artworks.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(8.0, 8.0, 8.0, 4.0),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          'Exhibits',
+                          style: TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.orange.shade800,
+                          ),
+                        ),
+                      ),
+                    ),
+                  Expanded(
                     // List of artworks from the API search
                     child: ArtworkResultsList(
-                  artworks: artworks,
-                  isLoadingMore: isLoadingMore,
-                  hasMore: hasMore,
-                  loadMore: () => _performSearch(searchTextController.text,
-                      isNewSearch: false),
-                )),
-              ],
+                      artworks: artworks,
+                      isLoadingMore: isLoadingMore,
+                      hasMore: hasMore,
+                      loadMore: () => _performSearch(searchTextController.text,
+                          isNewSearch: false),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
           // Search suggestions

--- a/lib/ui/widgets/exhibits_menu.dart
+++ b/lib/ui/widgets/exhibits_menu.dart
@@ -103,15 +103,16 @@ class _ExhibitsMenuState extends State<ExhibitsMenu> {
           onPressed: () => showExhibits(false),
         ),
         title: const Text("Search Exhibits"),
-        backgroundColor: Colors.white,
-        foregroundColor: Colors.orange.shade800,
+        backgroundColor: const Color(0xFF1E1E1E), // Dark background for app bar
+        foregroundColor:
+            const Color(0xFFFF7D00), // Brighter orange for dark mode
         elevation: 2,
       ),
       body: Stack(
         children: <Widget>[
           // Content of the screen, including artworks list
           Container(
-            color: Colors.grey.shade50,
+            color: const Color(0xFF121212), // Dark background for body
             child: Padding(
               padding: const EdgeInsets.all(8.0),
               child: Column(
@@ -141,7 +142,8 @@ class _ExhibitsMenuState extends State<ExhibitsMenu> {
                           style: TextStyle(
                             fontSize: 20,
                             fontWeight: FontWeight.bold,
-                            color: Colors.orange.shade800,
+                            color: const Color(
+                                0xFFFF7D00), // Brighter orange for dark mode
                           ),
                         ),
                       ),

--- a/lib/ui/widgets/map/map_widget.dart
+++ b/lib/ui/widgets/map/map_widget.dart
@@ -76,14 +76,14 @@ class _MapWidgetState extends State<MapWidget> {
     PolygonArea? toRoomPolygon;
 
     if (widget.fromRoom != null) {
-      fromRoomPolygon = floorPolygons.firstWhere(
-        (polygon) => polygon.id == widget.fromRoom!.id,
+      fromRoomPolygon = widget.polygons.firstWhere(
+        (polygon) => polygon.id == widget.fromRoom!.id
       );
     }
 
     if (widget.toRoom != null) {
-      toRoomPolygon = floorPolygons.firstWhere(
-        (polygon) => polygon.id == widget.toRoom!.id,
+      toRoomPolygon = widget.polygons.firstWhere(
+        (polygon) => polygon.id == widget.toRoom!.id
       );
     }
 

--- a/lib/ui/widgets/polygon_info_panel.dart
+++ b/lib/ui/widgets/polygon_info_panel.dart
@@ -29,8 +29,8 @@ class PolygonInfoPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
-    final panelHeight =
-        screenSize.height * 0.4 > 300 ? 300 : screenSize.height * 0.4;
+    // Use 50% of screen height for the panel
+    final panelHeight = screenSize.height * 0.5;
     return Container(
       width: double.infinity,
       height: panelHeight.toDouble(),
@@ -49,153 +49,162 @@ class PolygonInfoPanel extends StatelessWidget {
           topRight: Radius.circular(16),
         ),
       ),
-      child: SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 8.0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  ElevatedButton.icon(
-                    onPressed: () {
-                      onShowRoute!(polygon.id);
-                    },
-                    icon: const Icon(Icons.alt_route),
-                    label: const Text("Show Route"),
-                    style: ElevatedButton.styleFrom(
-                      foregroundColor: Colors.white,
-                      backgroundColor: Colors.orange.shade800,
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 24, vertical: 12),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Room details directly at the top with no padding
+          Container(
+            padding: const EdgeInsets.fromLTRB(16.0, 0.0, 0.0, 0.0),
+            height: 40, // Fixed height to ensure consistent positioning
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                // Room information on a single row
+                Expanded(
+                  child: Row(
+                    children: [
+                      Text(
+                        polygon.name,
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: Colors.orange.shade800,
+                          fontSize: 16,
+                        ),
+                        overflow: TextOverflow.ellipsis,
                       ),
-                    ),
+                      const SizedBox(width: 8),
+                      Text(
+                        '${polygon.type} • Floor ${polygon.additionalData?['floor']?.toString() ?? 'N/A'}',
+                        style: TextStyle(
+                          color: Colors.grey.shade700,
+                          fontSize: 14,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                   ),
-                  IconButton(
-                    icon: const Icon(Icons.close, color: Colors.orange),
-                    onPressed: onClose,
-                    tooltip: 'Close Panel',
-                  ),
-                ],
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close, color: Colors.orange),
+                  onPressed: onClose,
+                  tooltip: 'Close Panel',
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                ),
+              ],
+            ),
+          ),
+
+          // Show Route button
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16.0, 4.0, 16.0, 0.0),
+            child: ElevatedButton.icon(
+              onPressed: () {
+                onShowRoute!(polygon.id);
+              },
+              icon: const Icon(Icons.alt_route),
+              label: const Text("Show Route"),
+              style: ElevatedButton.styleFrom(
+                foregroundColor: Colors.white,
+                backgroundColor: Colors.orange.shade800,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 24, vertical: 4),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
               ),
             ),
-            const Divider(),
-            Flexible(
-              child: Row(
+          ),
+
+          const Divider(height: 4),
+
+          // Exhibits section
+          Flexible(
+            child: SingleChildScrollView(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 8.0, vertical: 0.0),
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Expanded(
-                    flex: 1,
-                    child: SingleChildScrollView(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'Room Details',
-                            style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  color: Colors.orange.shade800,
-                                ),
-                          ),
-                          _buildInfoRow(context, 'Name', polygon.name),
-                          _buildInfoRow(context, 'Type', polygon.type),
-                          if (polygon.additionalData != null) ...[
-                            _buildInfoRow(
-                              context,
-                              'Floor',
-                              polygon.additionalData!['floor']?.toString() ?? 'N/A',
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
+                  Text(
+                    'Exhibits',
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: Colors.orange.shade800,
+                        ),
                   ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    flex: 1,
-                    child: SingleChildScrollView(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'Exhibits',
-                            style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  color: Colors.orange.shade800,
-                                ),
+                  // Use SizedBox with zero height to eliminate any default spacing
+                  const SizedBox(height: 0),
+                  FutureBuilder<List<dynamic>>(
+                    future: _fetchExhibits(polygon.id),
+                    builder: (context, snapshot) {
+                      if (snapshot.connectionState == ConnectionState.waiting) {
+                        return const Text(
+                          'Fetching exhibits...',
+                          style: TextStyle(fontSize: 16),
+                        );
+                      } else if (snapshot.hasError) {
+                        return Text('Error: ${snapshot.error}');
+                      } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                        return const Text('No exhibits on display.');
+                      } else {
+                        final exhibits = snapshot.data!;
+                        return GridView.builder(
+                          padding: EdgeInsets.zero,
+                          shrinkWrap: true,
+                          physics: const NeverScrollableScrollPhysics(),
+                          gridDelegate:
+                              SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: 2,
+                            crossAxisSpacing: 10.0,
+                            mainAxisSpacing: 8.0,
+                            childAspectRatio:
+                                MediaQuery.of(context).size.width > 600
+                                    ? 1.2
+                                    : 0.9,
                           ),
-                          FutureBuilder<List<dynamic>>(
-                            future: _fetchExhibits(polygon.id),
-                            builder: (context, snapshot) {
-                              if (snapshot.connectionState == ConnectionState.waiting) {
-                                return const Text(
-                                  'Fetching exhibits...',
-                                  style: TextStyle(fontSize: 16),
-                                );
-                              } else if (snapshot.hasError) {
-                                return Text('Error: ${snapshot.error}');
-                              } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
-                                return const Text('No exhibits on display.');
-                              } else {
-                                final exhibits = snapshot.data!;
-                                return ListView.builder(
-                                  shrinkWrap: true,
-                                  physics: const NeverScrollableScrollPhysics(),
-                                  itemCount: exhibits.length,
-                                  itemBuilder: (context, index) {
-                                    final exhibit = exhibits[index];
-                                    final title = (exhibit['titles'] as List?)?.isNotEmpty == true
-                                        ? exhibit['titles'][0]['title'] ?? 'Untitled'
-                                        : 'Untitled';
-                                    final artist = (exhibit['artist'] as List?)?.isNotEmpty == true
-                                        ? exhibit['artist'][0] ?? 'Unknown'
-                                        : 'Unknown';
-                                    final String? thumbnail = exhibit['image_thumbnail'];
-                                    final String? frontendUrl = exhibit['frontend_url'];
-                                    return Padding(
-                                      padding: const EdgeInsets.symmetric(vertical: 2.0),
-                                      child: Row(
-                                        crossAxisAlignment: CrossAxisAlignment.start,
-                                        children: [
-                                          Expanded(
-                                            child: _buildInfoRow(
-                                              context,
-                                              artist,
-                                              title,
-                                              thumbnail,
-                                              frontendUrl,
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    );
-                                  },
-                                );
-                              }
-                            },
-                          ),
-                        ],
-                      ),
-                    ),
+                          itemCount: exhibits.length,
+                          itemBuilder: (context, index) {
+                            final exhibit = exhibits[index];
+                            final title =
+                                (exhibit['titles'] as List?)?.isNotEmpty == true
+                                    ? exhibit['titles'][0]['title'] ??
+                                        'Untitled'
+                                    : 'Untitled';
+                            final artist =
+                                (exhibit['artist'] as List?)?.isNotEmpty == true
+                                    ? exhibit['artist'][0] ?? 'Unknown'
+                                    : 'Unknown';
+                            final String? thumbnail =
+                                exhibit['image_thumbnail'];
+                            final String? frontendUrl = exhibit['frontend_url'];
+                            return _buildExhibitCard(
+                              context,
+                              artist,
+                              title,
+                              thumbnail,
+                              frontendUrl,
+                            );
+                          },
+                        );
+                      }
+                    },
                   ),
                 ],
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
 
-  Widget _buildInfoRow(BuildContext context, String label, String value, [String? thumbnail, String? frontendUrl]) {
+  // Keep the original _buildInfoRow method for compatibility
+  Widget _buildInfoRow(BuildContext context, String label, String value,
+      [String? thumbnail, String? frontendUrl]) {
     final content = Container(
-      margin: const EdgeInsets.symmetric(vertical: 6.0),
-      padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+      margin: const EdgeInsets.symmetric(vertical: 2.0),
+      padding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 2.0),
       decoration: BoxDecoration(
         color: Colors.grey.shade100,
         borderRadius: BorderRadius.circular(8),
@@ -236,29 +245,171 @@ class PolygonInfoPanel extends StatelessWidget {
     );
 
     return frontendUrl != null && frontendUrl.isNotEmpty
-      ? GestureDetector(
-        onTap: () async {
-          final open = await showDialog<bool>(
-            context: context,
-            builder: (context) => AlertDialog(
-              title: const Text('Do you want to open this link?'),
-              content: Text(frontendUrl),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(false),
-                  child: const Text('Cancel'),
+        ? GestureDetector(
+            onTap: () async {
+              final open = await showDialog<bool>(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('Do you want to open this link?'),
+                  content: Text(frontendUrl),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      child: const Text('Cancel'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(true),
+                      child: const Text('Open'),
+                    ),
+                  ],
                 ),
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(true),
-                  child: const Text('Open'),
+              );
+              if (open!) launchUrl(Uri.parse(frontendUrl));
+            },
+            child: content,
+          )
+        : content;
+  }
+
+  Widget _buildExhibitCard(BuildContext context, String artist, String title,
+      [String? thumbnail, String? frontendUrl]) {
+    final bool hasLink = frontendUrl != null && frontendUrl.isNotEmpty;
+
+    final card = Card(
+      elevation: hasLink ? 4.0 : 3.0,
+      clipBehavior:
+          Clip.antiAlias, // Ensures image doesn't overflow rounded corners
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12.0),
+        side: BorderSide(
+          color: hasLink ? Colors.orange.shade300 : Colors.grey.shade300,
+          width: hasLink ? 1.0 : 0.5,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Image section
+          if (thumbnail != null && thumbnail.isNotEmpty)
+            Expanded(
+              flex: 5,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.grey.shade200,
+                ),
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    Image.network(
+                      thumbnail,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) => Center(
+                          child: Icon(Icons.broken_image,
+                              size: 40, color: Colors.grey.shade400)),
+                    ),
+                    // Gradient overlay for better text readability if needed
+                    Positioned(
+                      bottom: 0,
+                      left: 0,
+                      right: 0,
+                      child: Container(
+                        height: 30,
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [
+                              Colors.transparent,
+                              Colors.black.withValues(alpha: 0.3),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+          // Text section
+          Expanded(
+            flex: 3,
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    artist == 'Ubekendt' ? 'Unknown' : artist,
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: Colors.orange.shade800,
+                      fontSize: 14,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    title,
+                    style: const TextStyle(fontSize: 12),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    return frontendUrl != null && frontendUrl.isNotEmpty
+        ? GestureDetector(
+            onTap: () async {
+              final open = await showDialog<bool>(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('Do you want to open this link?'),
+                  content: Text(frontendUrl),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      child: const Text('Cancel'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(true),
+                      child: const Text('Open'),
+                    ),
+                  ],
+                ),
+              );
+              if (open!) launchUrl(Uri.parse(frontendUrl));
+            },
+            child: Stack(
+              children: [
+                card,
+                Positioned(
+                  top: 8,
+                  right: 8,
+                  child: Container(
+                    padding: const EdgeInsets.all(4),
+                    decoration: BoxDecoration(
+                      color: const Color.fromARGB(255, 255, 255, 255)
+                          .withValues(alpha: 0.8),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Icon(
+                      Icons.open_in_new,
+                      size: 16,
+                      color: Colors.orange.shade800,
+                    ),
+                  ),
                 ),
               ],
             ),
-          );
-          if (open!) launchUrl(Uri.parse(frontendUrl));
-        },
-        child: content,
-      )
-      : content;
+          )
+        : card;
   }
 }

--- a/lib/ui/widgets/polygon_info_panel.dart
+++ b/lib/ui/widgets/polygon_info_panel.dart
@@ -69,7 +69,7 @@ class PolygonInfoPanel extends StatelessWidget {
                     children: [
                       Text(
                         polygon.name,
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontWeight: FontWeight.bold,
                           color: Color(0xFFFF7D00), // Brighter orange
                           fontSize: 16,
@@ -112,7 +112,7 @@ class PolygonInfoPanel extends StatelessWidget {
               label: const Text("Show Route"),
               style: ElevatedButton.styleFrom(
                 foregroundColor: Colors.white,
-                backgroundColor: Color(0xFFFF7D00), // Brighter orange
+                backgroundColor: const Color(0xFFFF7D00), // Brighter orange
                 padding:
                     const EdgeInsets.symmetric(horizontal: 24, vertical: 4),
                 shape: RoundedRectangleBorder(
@@ -136,7 +136,7 @@ class PolygonInfoPanel extends StatelessWidget {
                     'Exhibits',
                     style: Theme.of(context).textTheme.titleLarge?.copyWith(
                           fontWeight: FontWeight.bold,
-                          color: Color(0xFFFF7D00), // Brighter orange
+                          color: const Color(0xFFFF7D00), // Brighter orange
                         ),
                   ),
                   // Use SizedBox with zero height to eliminate any default spacing

--- a/lib/ui/widgets/polygon_info_panel.dart
+++ b/lib/ui/widgets/polygon_info_panel.dart
@@ -92,7 +92,7 @@ class PolygonInfoPanelState extends State<PolygonInfoPanel> {
                   child: Row(
                     children: [
                       Text(
-                        polygon.name,
+                        widget.polygon.name,
                         style: const TextStyle(
                           fontWeight: FontWeight.bold,
                           color: Color(0xFFFF7D00), // Brighter orange
@@ -102,7 +102,7 @@ class PolygonInfoPanelState extends State<PolygonInfoPanel> {
                       ),
                       const SizedBox(width: 8),
                       Text(
-                        '${polygon.type} • Floor ${polygon.additionalData?['floor']?.toString() ?? 'N/A'}',
+                        '${widget.polygon.type} • Floor ${widget.polygon.additionalData?['floor']?.toString() ?? 'N/A'}',
                         style: TextStyle(
                           color: Colors
                               .grey.shade400, // Lighter gray for visibility
@@ -116,7 +116,7 @@ class PolygonInfoPanelState extends State<PolygonInfoPanel> {
                 IconButton(
                   icon: const Icon(Icons.close,
                       color: Color(0xFFFF7D00)), // Brighter orange
-                  onPressed: onClose,
+                  onPressed: widget.onClose,
                   tooltip: 'Close Panel',
                   padding: EdgeInsets.zero,
                   constraints: const BoxConstraints(),
@@ -130,7 +130,7 @@ class PolygonInfoPanelState extends State<PolygonInfoPanel> {
             padding: const EdgeInsets.fromLTRB(16.0, 4.0, 16.0, 0.0),
             child: ElevatedButton.icon(
               onPressed: () {
-                onShowRoute!(polygon.id);
+                widget.onShowRoute!(widget.polygon.id);
               },
               icon: const Icon(Icons.alt_route),
               label: const Text("Show Route"),
@@ -166,7 +166,7 @@ class PolygonInfoPanelState extends State<PolygonInfoPanel> {
                   // Use SizedBox with zero height to eliminate any default spacing
                   const SizedBox(height: 0),
                   FutureBuilder<List<dynamic>>(
-                    future: _fetchExhibits(polygon.id),
+                    future: _fetchExhibits(widget.polygon.id),
                     builder: (context, snapshot) {
                       if (snapshot.connectionState == ConnectionState.waiting) {
                         return const Text(

--- a/lib/ui/widgets/polygon_info_panel.dart
+++ b/lib/ui/widgets/polygon_info_panel.dart
@@ -22,14 +22,12 @@ class PolygonInfoPanel extends StatefulWidget {
 }
 
 class PolygonInfoPanelState extends State<PolygonInfoPanel> {
-  late Future<List<dynamic>> _exhibitFuture;
   late String _lastPolygonId;
 
   @override
   void initState() {
     super.initState();
     _lastPolygonId = widget.polygon.id;
-    _exhibitFuture = _fetchExhibits(_lastPolygonId);
   }
 
   @override
@@ -37,7 +35,6 @@ class PolygonInfoPanelState extends State<PolygonInfoPanel> {
     super.didUpdateWidget(oldWidget);
     if (widget.polygon.id != _lastPolygonId) {
       _lastPolygonId = widget.polygon.id;
-      _exhibitFuture = _fetchExhibits(_lastPolygonId);
     }
   }
 
@@ -204,7 +201,7 @@ class PolygonInfoPanelState extends State<PolygonInfoPanel> {
                             childAspectRatio:
                                 MediaQuery.of(context).size.width > 600
                                     ? 1.2
-                                    : 0.85, // Changed from 0.9 to 0.85
+                                    : 0.75, // Changed from 0.9 to 0.85
 
                           ),
                           itemCount: exhibits.length,

--- a/lib/ui/widgets/polygon_info_panel.dart
+++ b/lib/ui/widgets/polygon_info_panel.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:indoor_crowded_regions_frontend/services/api_service.dart';
+import 'package:indoor_crowded_regions_frontend/ui/components/error_toast.dart';
 import '../../models/polygon_area.dart';
-import 'package:url_launcher/url_launcher.dart';
+import '../components/exhibit_card.dart';
+import '../components/exhibit_detail_dialog.dart';
 
 class PolygonInfoPanel extends StatelessWidget {
   final PolygonArea polygon;
@@ -35,15 +37,17 @@ class PolygonInfoPanel extends StatelessWidget {
       width: double.infinity,
       height: panelHeight.toDouble(),
       decoration: const BoxDecoration(
-        color: Colors.white,
+        color: Color(0xFF1E1E1E), // Dark background for panel
         boxShadow: [
           BoxShadow(
-            color: Colors.black45,
+            color: Colors.black87,
             blurRadius: 10,
             spreadRadius: 2,
           ),
         ],
-        border: Border(top: BorderSide(color: Colors.orange, width: 3)),
+        border: Border(
+            top: BorderSide(
+                color: Color(0xFFFF7D00), width: 3)), // Brighter orange
         borderRadius: BorderRadius.only(
           topLeft: Radius.circular(16),
           topRight: Radius.circular(16),
@@ -67,7 +71,7 @@ class PolygonInfoPanel extends StatelessWidget {
                         polygon.name,
                         style: TextStyle(
                           fontWeight: FontWeight.bold,
-                          color: Colors.orange.shade800,
+                          color: Color(0xFFFF7D00), // Brighter orange
                           fontSize: 16,
                         ),
                         overflow: TextOverflow.ellipsis,
@@ -76,7 +80,8 @@ class PolygonInfoPanel extends StatelessWidget {
                       Text(
                         '${polygon.type} • Floor ${polygon.additionalData?['floor']?.toString() ?? 'N/A'}',
                         style: TextStyle(
-                          color: Colors.grey.shade700,
+                          color: Colors
+                              .grey.shade400, // Lighter gray for visibility
                           fontSize: 14,
                         ),
                         overflow: TextOverflow.ellipsis,
@@ -85,7 +90,8 @@ class PolygonInfoPanel extends StatelessWidget {
                   ),
                 ),
                 IconButton(
-                  icon: const Icon(Icons.close, color: Colors.orange),
+                  icon: const Icon(Icons.close,
+                      color: Color(0xFFFF7D00)), // Brighter orange
                   onPressed: onClose,
                   tooltip: 'Close Panel',
                   padding: EdgeInsets.zero,
@@ -106,7 +112,7 @@ class PolygonInfoPanel extends StatelessWidget {
               label: const Text("Show Route"),
               style: ElevatedButton.styleFrom(
                 foregroundColor: Colors.white,
-                backgroundColor: Colors.orange.shade800,
+                backgroundColor: Color(0xFFFF7D00), // Brighter orange
                 padding:
                     const EdgeInsets.symmetric(horizontal: 24, vertical: 4),
                 shape: RoundedRectangleBorder(
@@ -116,7 +122,7 @@ class PolygonInfoPanel extends StatelessWidget {
             ),
           ),
 
-          const Divider(height: 4),
+          const Divider(height: 4, color: Color(0xFF3D3D3D)), // Dark divider
 
           // Exhibits section
           Flexible(
@@ -130,7 +136,7 @@ class PolygonInfoPanel extends StatelessWidget {
                     'Exhibits',
                     style: Theme.of(context).textTheme.titleLarge?.copyWith(
                           fontWeight: FontWeight.bold,
-                          color: Colors.orange.shade800,
+                          color: Color(0xFFFF7D00), // Brighter orange
                         ),
                   ),
                   // Use SizedBox with zero height to eliminate any default spacing
@@ -141,12 +147,24 @@ class PolygonInfoPanel extends StatelessWidget {
                       if (snapshot.connectionState == ConnectionState.waiting) {
                         return const Text(
                           'Fetching exhibits...',
-                          style: TextStyle(fontSize: 16),
+                          style: TextStyle(
+                              fontSize: 16,
+                              color:
+                                  Colors.white70), // Light text for dark mode
                         );
                       } else if (snapshot.hasError) {
-                        return Text('Error: ${snapshot.error}');
+                        return Text(
+                          'Error: ${snapshot.error}',
+                          style: TextStyle(
+                              color: Colors.red.shade300), // Error text color
+                        );
                       } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
-                        return const Text('No exhibits on display.');
+                        return const Text(
+                          'No exhibits on display.',
+                          style: TextStyle(
+                              color:
+                                  Colors.white70), // Light text for dark mode
+                        );
                       } else {
                         final exhibits = snapshot.data!;
                         return GridView.builder(
@@ -158,32 +176,25 @@ class PolygonInfoPanel extends StatelessWidget {
                             crossAxisCount: 2,
                             crossAxisSpacing: 10.0,
                             mainAxisSpacing: 8.0,
+                            // Slightly adjust the aspect ratio to fix the small overflow
                             childAspectRatio:
                                 MediaQuery.of(context).size.width > 600
                                     ? 1.2
-                                    : 0.9,
+                                    : 0.85, // Changed from 0.9 to 0.85
                           ),
                           itemCount: exhibits.length,
                           itemBuilder: (context, index) {
                             final exhibit = exhibits[index];
-                            final title =
-                                (exhibit['titles'] as List?)?.isNotEmpty == true
-                                    ? exhibit['titles'][0]['title'] ??
-                                        'Untitled'
-                                    : 'Untitled';
-                            final artist =
-                                (exhibit['artist'] as List?)?.isNotEmpty == true
-                                    ? exhibit['artist'][0] ?? 'Unknown'
-                                    : 'Unknown';
-                            final String? thumbnail =
-                                exhibit['image_thumbnail'];
                             final String? frontendUrl = exhibit['frontend_url'];
-                            return _buildExhibitCard(
-                              context,
-                              artist,
-                              title,
-                              thumbnail,
-                              frontendUrl,
+                            return Padding(
+                              padding: const EdgeInsets.all(2.0),
+                              child: ExhibitCard(
+                                exhibit: exhibit,
+                                hasLink: frontendUrl != null &&
+                                    frontendUrl.isNotEmpty,
+                                onTap: () =>
+                                    _showExhibitDetails(context, exhibit),
+                              ),
                             );
                           },
                         );
@@ -199,217 +210,17 @@ class PolygonInfoPanel extends StatelessWidget {
     );
   }
 
-  // Keep the original _buildInfoRow method for compatibility
-  Widget _buildInfoRow(BuildContext context, String label, String value,
-      [String? thumbnail, String? frontendUrl]) {
-    final content = Container(
-      margin: const EdgeInsets.symmetric(vertical: 2.0),
-      padding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 2.0),
-      decoration: BoxDecoration(
-        color: Colors.grey.shade100,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: Colors.grey.shade300),
-      ),
-      child: Row(
-        children: [
-          Text(
-            label == 'Ubekendt' ? 'Unknown' : label,
-            style: TextStyle(
-              fontWeight: FontWeight.bold,
-              color: Colors.orange.shade800,
-              fontSize: 16,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              value,
-              style: const TextStyle(fontSize: 16),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          if (thumbnail != null && thumbnail.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.only(left: 8.0),
-              child: Image.network(
-                thumbnail,
-                width: 40,
-                height: 40,
-                fit: BoxFit.cover,
-                errorBuilder: (context, error, stackTrace) =>
-                    const Icon(Icons.broken_image),
-              ),
-            ),
-        ],
-      ),
-    );
-
-    return frontendUrl != null && frontendUrl.isNotEmpty
-        ? GestureDetector(
-            onTap: () async {
-              final open = await showDialog<bool>(
-                context: context,
-                builder: (context) => AlertDialog(
-                  title: const Text('Do you want to open this link?'),
-                  content: Text(frontendUrl),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(false),
-                      child: const Text('Cancel'),
-                    ),
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(true),
-                      child: const Text('Open'),
-                    ),
-                  ],
-                ),
-              );
-              if (open!) launchUrl(Uri.parse(frontendUrl));
-            },
-            child: content,
-          )
-        : content;
-  }
-
-  Widget _buildExhibitCard(BuildContext context, String artist, String title,
-      [String? thumbnail, String? frontendUrl]) {
-    final bool hasLink = frontendUrl != null && frontendUrl.isNotEmpty;
-
-    final card = Card(
-      elevation: hasLink ? 4.0 : 3.0,
-      clipBehavior:
-          Clip.antiAlias, // Ensures image doesn't overflow rounded corners
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12.0),
-        side: BorderSide(
-          color: hasLink ? Colors.orange.shade300 : Colors.grey.shade300,
-          width: hasLink ? 1.0 : 0.5,
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Image section
-          if (thumbnail != null && thumbnail.isNotEmpty)
-            Expanded(
-              flex: 5,
-              child: Container(
-                decoration: BoxDecoration(
-                  color: Colors.grey.shade200,
-                ),
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    Image.network(
-                      thumbnail,
-                      fit: BoxFit.cover,
-                      errorBuilder: (context, error, stackTrace) => Center(
-                          child: Icon(Icons.broken_image,
-                              size: 40, color: Colors.grey.shade400)),
-                    ),
-                    // Gradient overlay for better text readability if needed
-                    Positioned(
-                      bottom: 0,
-                      left: 0,
-                      right: 0,
-                      child: Container(
-                        height: 30,
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            begin: Alignment.topCenter,
-                            end: Alignment.bottomCenter,
-                            colors: [
-                              Colors.transparent,
-                              Colors.black.withValues(alpha: 0.3),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-
-          // Text section
-          Expanded(
-            flex: 3,
-            child: Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    artist == 'Ubekendt' ? 'Unknown' : artist,
-                    style: TextStyle(
-                      fontWeight: FontWeight.bold,
-                      color: Colors.orange.shade800,
-                      fontSize: 14,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    title,
-                    style: const TextStyle(fontSize: 12),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-
-    return frontendUrl != null && frontendUrl.isNotEmpty
-        ? GestureDetector(
-            onTap: () async {
-              final open = await showDialog<bool>(
-                context: context,
-                builder: (context) => AlertDialog(
-                  title: const Text('Do you want to open this link?'),
-                  content: Text(frontendUrl),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(false),
-                      child: const Text('Cancel'),
-                    ),
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(true),
-                      child: const Text('Open'),
-                    ),
-                  ],
-                ),
-              );
-              if (open!) launchUrl(Uri.parse(frontendUrl));
-            },
-            child: Stack(
-              children: [
-                card,
-                Positioned(
-                  top: 8,
-                  right: 8,
-                  child: Container(
-                    padding: const EdgeInsets.all(4),
-                    decoration: BoxDecoration(
-                      color: const Color.fromARGB(255, 255, 255, 255)
-                          .withValues(alpha: 0.8),
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Icon(
-                      Icons.open_in_new,
-                      size: 16,
-                      color: Colors.orange.shade800,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          )
-        : card;
+  /// Show the exhibit details dialog
+  void _showExhibitDetails(BuildContext context, dynamic exhibit) {
+    try {
+      // Show the dialog with the exhibit data
+      showDialog(
+        context: context,
+        builder: (context) => ExhibitDetailDialog(exhibit: exhibit),
+      );
+    } catch (e) {
+      // Handle any errors that might occur during dialog creation
+      ErrorToast.show("Could not create dialog screen.");
+    }
   }
 }

--- a/lib/ui/widgets/top_bar.dart
+++ b/lib/ui/widgets/top_bar.dart
@@ -13,17 +13,16 @@ class TopBar extends StatefulWidget {
   final VoidCallback? onGetDirections;
   final Function? setEdgesFuture;
 
-  const TopBar({
-    super.key,
-    this.fromRoom,
-    this.toRoom,
-    this.gatewayService,
-    this.onClose,
-    this.onFromPressed,
-    this.onToPressed,
-    this.onGetDirections,
-    this.setEdgesFuture
-  });
+  const TopBar(
+      {super.key,
+      this.fromRoom,
+      this.toRoom,
+      this.gatewayService,
+      this.onClose,
+      this.onFromPressed,
+      this.onToPressed,
+      this.onGetDirections,
+      this.setEdgesFuture});
 
   @override
   State<TopBar> createState() => _TopBarState();
@@ -37,8 +36,10 @@ class _TopBarState extends State<TopBar> {
   @override
   void initState() {
     super.initState();
-    _fromController = TextEditingController(text: widget.fromRoom?.name ?? "Select starting point");
-    _toController = TextEditingController(text: widget.toRoom?.name ?? "Select destination");
+    _fromController = TextEditingController(
+        text: widget.fromRoom?.name ?? "Select starting point");
+    _toController = TextEditingController(
+        text: widget.toRoom?.name ?? "Select destination");
     _gatewayService = widget.gatewayService ?? GatewayService();
   }
 
@@ -60,7 +61,6 @@ class _TopBarState extends State<TopBar> {
     super.dispose();
   }
 
-
   void _fetchRoute() {
     if (widget.fromRoom?.id != null && widget.toRoom?.id != null) {
       final res = _gatewayService!.getFastestRouteWithCoordinates(
@@ -70,10 +70,11 @@ class _TopBarState extends State<TopBar> {
 
       widget.setEdgesFuture!(res);
 
-       ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Calculating route from ${widget.fromRoom?.name ?? 'Start'} to ${widget.toRoom?.name ?? 'End'}...'),
-          backgroundColor: Colors.blueAccent,
+          content: Text(
+              'Calculating route from ${widget.fromRoom?.name ?? 'Start'} to ${widget.toRoom?.name ?? 'End'}...'),
+          backgroundColor: Colors.blue.shade700, // Darker blue for dark mode
           duration: const Duration(seconds: 2),
         ),
       );
@@ -81,29 +82,31 @@ class _TopBarState extends State<TopBar> {
       res.then((routeData) {
         if (routeData.isNotEmpty && mounted) {
         } else if (routeData.isEmpty && mounted) {
-             ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                content: Text('Could not find a route between the selected points.'),
-                backgroundColor: Colors.orangeAccent,
-                ),
-            );
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const Text(
+                  'Could not find a route between the selected points.'),
+              backgroundColor:
+                  Colors.orange.shade700, // Darker orange for dark mode
+            ),
+          );
         }
       }).catchError((error) {
-          if (mounted) {
-               ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                content: Text('Error calculating route: $error'),
-                backgroundColor: Colors.redAccent,
-                ),
-            );
-          }
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Error calculating route: $error'),
+              backgroundColor: Colors.red.shade700, // Darker red for dark mode
+            ),
+          );
+        }
       });
-
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Please select both a starting point and a destination on the map.'),
-          backgroundColor: Colors.redAccent,
+        SnackBar(
+          content: const Text(
+              'Please select both a starting point and a destination on the map.'),
+          backgroundColor: Colors.red.shade700, // Darker red for dark mode
         ),
       );
     }
@@ -114,18 +117,20 @@ class _TopBarState extends State<TopBar> {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-         color: Colors.white.withValues(alpha: 0.95),
-         borderRadius: const BorderRadius.only(
-              bottomLeft: Radius.circular(16),
-              bottomRight: Radius.circular(16),
-         ),
-         boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: 0.1),
-                blurRadius: 8,
-                offset: const Offset(0, 4),
-              ),
-         ],
+        color: const Color(0xFF1E1E1E)
+            .withValues(alpha: 0.95), // Dark background for top bar
+        borderRadius: const BorderRadius.only(
+          bottomLeft: Radius.circular(16),
+          bottomRight: Radius.circular(16),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black
+                .withValues(alpha: 0.3), // Darker shadow for visibility
+            blurRadius: 8,
+            offset: const Offset(0, 4),
+          ),
+        ],
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -133,17 +138,18 @@ class _TopBarState extends State<TopBar> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-               const Text(
-                  "Route Planner",
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.black87,
-                  ),
-               ),
+              const Text(
+                "Route Planner",
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white, // Light text for dark mode
+                ),
+              ),
               if (widget.onClose != null)
                 IconButton(
-                  icon: const Icon(Icons.close, color: Colors.black54),
+                  icon: const Icon(Icons.close,
+                      color: Colors.white70), // Light icon for dark mode
                   onPressed: widget.onClose,
                   tooltip: "Close Route Planner",
                 ),
@@ -189,7 +195,8 @@ class _TopBarState extends State<TopBar> {
           label: const Text("Get Directions"),
           style: ElevatedButton.styleFrom(
             foregroundColor: Colors.white,
-            backgroundColor: Colors.orange.shade700,
+            backgroundColor:
+                const Color(0xFFFF7D00), // Brighter orange for dark mode
             padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),
@@ -200,6 +207,4 @@ class _TopBarState extends State<TopBar> {
       ],
     );
   }
-
-  
 }

--- a/lib/ui/widgets/utils/input_field.dart
+++ b/lib/ui/widgets/utils/input_field.dart
@@ -1,31 +1,38 @@
 import 'package:flutter/material.dart';
 
 Widget buildInputField({
-    required TextEditingController controller,
-    required String hint,
-    required IconData icon,
-  }) {
-    return Container(
-       padding: const EdgeInsets.symmetric(horizontal: 8),
-      decoration: BoxDecoration(
-        color: Colors.grey.shade200,
-        borderRadius: BorderRadius.circular(8),
+  required TextEditingController controller,
+  required String hint,
+  required IconData icon,
+}) {
+  return Container(
+    padding: const EdgeInsets.symmetric(horizontal: 8),
+    decoration: BoxDecoration(
+      color: const Color(0xFF2D2D2D), // Dark background for input field
+      borderRadius: BorderRadius.circular(8),
+    ),
+    child: TextField(
+      controller: controller,
+      readOnly: true,
+      enableInteractiveSelection: false,
+      style: TextStyle(
+        color: controller.text.startsWith("Select")
+            ? Colors.grey.shade400
+            : Colors.white, // Light text for dark mode
+        fontWeight: controller.text.startsWith("Select")
+            ? FontWeight.normal
+            : FontWeight.w500,
       ),
-      child: TextField(
-        controller: controller,
-        readOnly: true,
-        enableInteractiveSelection: false,
-        style: TextStyle(
-           color: controller.text.startsWith("Select") ? Colors.grey.shade600 : Colors.black87,
-           fontWeight: controller.text.startsWith("Select") ? FontWeight.normal : FontWeight.w500,
-        ),
-        decoration: InputDecoration(
-          prefixIcon: Icon(icon, color: Colors.orange.shade700, size: 20),
-          hintText: hint,
-          hintStyle: TextStyle(color: Colors.grey.shade500),
-          border: InputBorder.none,
-          contentPadding: const EdgeInsets.symmetric(vertical: 14),
-        ),
+      decoration: InputDecoration(
+        prefixIcon: Icon(icon,
+            color: const Color(0xFFFF7D00),
+            size: 20), // Brighter orange for dark mode
+        hintText: hint,
+        hintStyle: TextStyle(
+            color: Colors.grey.shade400), // Lighter gray for visibility
+        border: InputBorder.none,
+        contentPadding: const EdgeInsets.symmetric(vertical: 14),
       ),
-    );
-  }
+    ),
+  );
+}

--- a/lib/utils/color_utils.dart
+++ b/lib/utils/color_utils.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+/// Utility class for color-related operations
+class ColorUtils {
+  /// Parse a color string into a Color object
+  static Color parseColorString(String colorString) {
+    try {
+      // Handle hex colors with # prefix
+      if (colorString.startsWith('#')) {
+        String hex = colorString.substring(1);
+        if (hex.length == 6) {
+          return Color(int.parse(hex, radix: 16) | 0xFF000000);
+        }
+      }
+
+      // Use a hash-based color for other strings
+      return Color((colorString.hashCode & 0xFFFFFF) | 0xFF000000);
+    } catch (e) {
+      // Default fallback color -- No idea on what we should do in this case, so lets hope it never happens
+      return Colors.grey;
+    }
+  }
+}

--- a/lib/utils/data_extractor.dart
+++ b/lib/utils/data_extractor.dart
@@ -1,0 +1,65 @@
+/// Utility class for extracting data from exhibit JSON
+class DataExtractor {
+  /// Extract a single value from the JSON response with error handling
+  static String extractValue(dynamic item, String key) {
+    try {
+      if (item == null || item[key] == null) return "Unknown";
+
+      if (item[key] is List) {
+        final list = item[key] as List;
+        if (list.isEmpty) return "Unknown";
+        return list[0].toString();
+      }
+
+      return item[key].toString();
+    } catch (e) {
+      // Return a default value if there's an error
+      return "Unknown";
+    }
+  }
+
+  /// Extract a list of values with error handling
+  static List<String> extractListValues(dynamic item, String key) {
+    try {
+      if (item == null || item[key] == null) return [];
+
+      if (item[key] is List) {
+        final list = item[key] as List;
+        return list.map((value) => value.toString()).toList();
+      }
+
+      return [];
+    } catch (e) {
+      // Return an empty list if there's an error
+      return [];
+    }
+  }
+
+  /// Extract title from exhibit data
+  static String extractTitle(dynamic exhibit) {
+    try {
+      final titles = exhibit["titles"] as List?;
+      return titles?.isNotEmpty == true
+          ? titles![0]["title"]?.toString() ?? "Untitled"
+          : "Untitled";
+    } catch (e) {
+      return "Untitled";
+    }
+  }
+
+  /// Extract artist from exhibit data
+  static String extractArtist(dynamic exhibit) {
+    try {
+      return (exhibit["artist"] as List?)?.isNotEmpty == true
+          ? exhibit["artist"][0] ?? "Unknown"
+          : "Unknown";
+    } catch (e) {
+      return "Unknown";
+    }
+  }
+
+  /// Extract location from exhibit data
+  static String extractLocation(dynamic exhibit) {
+    return exhibit["current_location_name"] ?? "Not on display";
+  }
+}

--- a/lib/utils/date_formatter.dart
+++ b/lib/utils/date_formatter.dart
@@ -1,0 +1,33 @@
+/// Utility class for formatting date information from exhibit data
+class DateFormatter {
+  /// Format dating information into a simple string
+  static String formatDating(dynamic exhibit) {
+    try {
+      // Check if production_date exists
+      if (exhibit["production_date"] == null) {
+        return "Unknown";
+      }
+
+      // Based on runtime analysis, we only need to handle the case where
+      // production_date is a List with a single Map item containing a period field
+      if (exhibit["production_date"] is List) {
+        final dateList = exhibit["production_date"] as List;
+        if (dateList.isNotEmpty) {
+          final firstDate = dateList[0];
+          if (firstDate is Map &&
+              firstDate.containsKey("period") &&
+              firstDate["period"] != null) {
+            return firstDate["period"].toString();
+          }
+        }
+      }
+
+      // Fallback: just convert to string
+      return exhibit["production_date"]
+          .toString()
+          .replaceAll(RegExp(r'[{}[\]]'), '');
+    } catch (e) {
+      return "Unknown";
+    }
+  }
+}

--- a/lib/utils/date_formatter.dart
+++ b/lib/utils/date_formatter.dart
@@ -1,31 +1,42 @@
 /// Utility class for formatting date information from exhibit data
 class DateFormatter {
-  /// Format dating information into a simple string
   static String formatDating(dynamic exhibit) {
     try {
-      // Check if production_date exists
-      if (exhibit["production_date"] == null) {
+      if (exhibit == null || exhibit["production_date"] == null) {
         return "Unknown";
       }
 
-      // Based on runtime analysis, we only need to handle the case where
-      // production_date is a List with a single Map item containing a period field
       if (exhibit["production_date"] is List) {
         final dateList = exhibit["production_date"] as List;
-        if (dateList.isNotEmpty) {
-          final firstDate = dateList[0];
-          if (firstDate is Map &&
-              firstDate.containsKey("period") &&
-              firstDate["period"] != null) {
-            return firstDate["period"].toString();
+        // Handle the case where the list is empty
+        if (dateList.isEmpty) {
+          return "Unknown";
+        }
+
+        // Now process the non-empty list
+        final firstDate = dateList[0];
+        if (firstDate is Map) {
+          if (firstDate.containsKey("period")) {
+            if (firstDate["period"] != null) {
+               return firstDate["period"].toString();
+            } else {
+               return "Unknown";
+            }
           }
         }
       }
 
-      // Fallback: just convert to string
-      return exhibit["production_date"]
-          .toString()
-          .replaceAll(RegExp(r'[{}[\]]'), '');
+      final date = exhibit["production_date"];
+       if (date != null) {
+         return date
+             .toString()
+             .replaceAll(RegExp(r'[{}[\]]'), '');
+       } else {
+         // This else might be redundant due to the initial null check,
+         // but provides a final safeguard.
+         return "Unknown";
+       }
+
     } catch (e) {
       return "Unknown";
     }

--- a/lib/utils/dimension_formatter.dart
+++ b/lib/utils/dimension_formatter.dart
@@ -1,0 +1,45 @@
+class DimensionFormatter {
+  static String? formatNettoDimensions(dynamic exhibit) {
+    final dimensions = exhibit["dimensions"];
+    if (dimensions == null || dimensions.isEmpty) return null;
+
+    double? height;
+    double? width;
+    double? depth;
+
+    for (final dim in dimensions) {
+      if (dim["part"] == "Netto" && dim["unit"] == "centimeter") {
+        final type = dim["type"];
+        final valueStr = dim["value"];
+        if (valueStr == null) continue;
+
+        final value = double.tryParse(valueStr);
+        if (value == null) continue;
+
+        if (type == "højde") {
+          height = value;
+        } else if (type == "bredde") {
+          width = value;
+        } else if (type == "dybde") {
+          depth = value;
+        }
+      }
+    }
+
+    List<String> parts = [];
+    if (height != null) parts.add("Height: ${_formatValue(height)} cm");
+    if (width != null) parts.add("Width: ${_formatValue(width)} cm");
+    if (depth != null) parts.add("Depth: ${_formatValue(depth)} cm");
+
+    if (parts.isEmpty) return null;
+    return parts.join(" × ");
+  }
+
+  static String _formatValue(double value) {
+    if (value % 1 == 0) {
+      return value.toInt().toString();
+    } else {
+      return value.toStringAsFixed(1);
+    }
+  }
+}

--- a/test/utils/data_extractor_test.dart
+++ b/test/utils/data_extractor_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:indoor_crowded_regions_frontend/utils/data_extractor.dart';
+
+void main() {
+  group('DataExtractor Tests', () {
+    test('extractValue should return value for existing key', () {
+      final item = {'name': 'Test Item', 'id': 123};
+      expect(DataExtractor.extractValue(item, 'name'), 'Test Item');
+      expect(DataExtractor.extractValue(item, 'id'), '123');
+    });
+
+    test('extractValue should return "Unknown" for missing key', () {
+      final item = {'name': 'Test Item'};
+      expect(DataExtractor.extractValue(item, 'description'), 'Unknown');
+    });
+
+    test('extractValue should return "Unknown" for null item', () {
+      expect(DataExtractor.extractValue(null, 'name'), 'Unknown');
+    });
+
+    test('extractValue should return "Unknown" for null value at key', () {
+      final item = {'name': null};
+      expect(DataExtractor.extractValue(item, 'name'), 'Unknown');
+    });
+
+    test('extractValue should return the first item for a list value', () {
+      final item = {
+        'tags': ['tag1', 'tag2']
+      };
+      expect(DataExtractor.extractValue(item, 'tags'), 'tag1');
+    });
+
+    test('extractValue should return "Unknown" for an empty list value', () {
+      final item = {'tags': []};
+      expect(DataExtractor.extractValue(item, 'tags'), 'Unknown');
+    });
+
+    test('extractListValues should return list of values for existing list key',
+        () {
+      final item = {
+        'tags': ['tag1', 'tag2', 'tag3']
+      };
+      expect(DataExtractor.extractListValues(item, 'tags'),
+          ['tag1', 'tag2', 'tag3']);
+    });
+
+    test(
+        'extractListValues should return empty list for existing non-list key',
+        () {
+      final item = {'name': 'Test Item'};
+      expect(DataExtractor.extractListValues(item, 'name'), []);
+    });
+
+    test('extractListValues should return empty list for missing key', () {
+      final item = {'name': 'Test Item'};
+      expect(DataExtractor.extractListValues(item, 'tags'), []);
+    });
+
+    test('extractListValues should return empty list for null item', () {
+      expect(DataExtractor.extractListValues(null, 'tags'), []);
+    });
+
+    test('extractListValues should return empty list for null value at key',
+        () {
+      final item = {'tags': null};
+      expect(DataExtractor.extractListValues(item, 'tags'), []);
+    });
+
+    test('extractListValues should return empty list on error', () {
+      // Simulate an error
+      final item = {
+        'tags': ComplexObject()
+      }; // Assuming ComplexObject is not a List
+      expect(DataExtractor.extractListValues(item, 'tags'), []);
+    });
+
+    test('extractTitle should return the first title from the list', () {
+      final exhibit = {
+        'titles': [
+          {'title': 'Main Title', 'lang': 'en'},
+          {'title': 'Alternate Title', 'lang': 'fr'}
+        ]
+      };
+      expect(DataExtractor.extractTitle(exhibit), 'Main Title');
+    });
+
+    test('extractTitle should return "Untitled" for missing "titles" key', () {
+      final exhibit = {'artist': 'Unknown'};
+      expect(DataExtractor.extractTitle(exhibit), 'Untitled');
+    });
+
+    test('extractTitle should return "Untitled" for empty "titles" list', () {
+      final exhibit = {'titles': []};
+      expect(DataExtractor.extractTitle(exhibit), 'Untitled');
+    });
+
+    test('extractTitle should return "Untitled" for null "titles" list', () {
+      final exhibit = {'titles': null};
+      expect(DataExtractor.extractTitle(exhibit), 'Untitled');
+    });
+
+    test('extractTitle should return "Untitled" if title in item is null', () {
+      final exhibit = {
+        'titles': [
+          {'title': null, 'lang': 'en'}
+        ]
+      };
+      expect(DataExtractor.extractTitle(exhibit), 'Untitled');
+    });
+
+    test('extractTitle should return "Untitled" on error', () {
+      // Simulate an error
+      final exhibit = {
+        'titles': ComplexObject()
+      }; // Assuming ComplexObject is not a List
+      expect(DataExtractor.extractTitle(exhibit), 'Untitled');
+    });
+
+    test('extractArtist should return the first artist from the list', () {
+      final exhibit = {
+        'artist': ['Artist Name 1', 'Artist Name 2']
+      };
+      expect(DataExtractor.extractArtist(exhibit), 'Artist Name 1');
+    });
+
+    test('extractArtist should return "Unknown" for missing "artist" key', () {
+      final exhibit = {'title': 'Test Title'};
+      expect(DataExtractor.extractArtist(exhibit), 'Unknown');
+    });
+
+    test('extractArtist should return "Unknown" for empty "artist" list', () {
+      final exhibit = {'artist': []};
+      expect(DataExtractor.extractArtist(exhibit), 'Unknown');
+    });
+
+    test('extractArtist should return "Unknown" for null "artist" list', () {
+      final exhibit = {'artist': null};
+      expect(DataExtractor.extractArtist(exhibit), 'Unknown');
+    });
+
+    test('extractArtist should return "Unknown" if artist in item is null', () {
+      final exhibit = {
+        'artist': [null]
+      };
+      expect(DataExtractor.extractArtist(exhibit), 'Unknown');
+    });
+
+    test('extractArtist should return "Unknown" on error', () {
+      // Simulate an error
+      final exhibit = {
+        'artist': ComplexObject()
+      }; // Assuming ComplexObject is not a List
+      expect(DataExtractor.extractArtist(exhibit), 'Unknown');
+    });
+
+    test('extractLocation should return location for existing key', () {
+      final exhibit = {'current_location_name': 'Gallery A'};
+      expect(DataExtractor.extractLocation(exhibit), 'Gallery A');
+    });
+
+    test('extractLocation should return "Not on display" for missing key', () {
+      final exhibit = {'title': 'Test Title'};
+      expect(DataExtractor.extractLocation(exhibit), 'Not on display');
+    });
+
+    test('extractLocation should return "Not on display" for null value at key',
+        () {
+      final exhibit = {'current_location_name': null};
+      expect(DataExtractor.extractLocation(exhibit), 'Not on display');
+    });
+  });
+}
+
+// Helper class to simulate a complex object that might cause an error
+class ComplexObject {}

--- a/test/utils/data_formatter_test.dart
+++ b/test/utils/data_formatter_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:indoor_crowded_regions_frontend/utils/date_formatter.dart';
+
+void main() {
+  group('DateFormatter Tests', () {
+    test('formatDating should return "Unknown" for missing production_date key',
+        () {
+      final exhibit = {'title': 'Test Title'};
+      expect(DateFormatter.formatDating(exhibit), 'Unknown');
+    });
+
+    test('formatDating should return "Unknown" for null production_date value',
+        () {
+      final exhibit = {'production_date': null};
+      expect(DateFormatter.formatDating(exhibit), 'Unknown');
+    });
+
+    test(
+        'formatDating should return the period string for a valid list structure',
+        () {
+      final exhibit = {
+        'production_date': [
+          {'period': '19th Century', 'details': 'Late 1800s'}
+        ]
+      };
+      expect(DateFormatter.formatDating(exhibit), '19th Century');
+    });
+
+    test('formatDating should return "Unknown" if period field is null', () {
+      final exhibit = {
+        'production_date': [
+          {'period': null, 'details': 'Late 1800s'}
+        ]
+      };
+      expect(DateFormatter.formatDating(exhibit), 'Unknown');
+    });
+
+    test('formatDating should return "Unknown" for an empty production_date list',
+        () {
+      final exhibit = {'production_date': []};
+      expect(DateFormatter.formatDating(exhibit), 'Unknown');
+    });
+
+    test(
+        'formatDating should return "details: Late 1800s" for a list item without the period key',
+        () {
+      final exhibit = {
+        'production_date': [
+          {'details': 'Late 1800s'}
+        ]
+      };
+      expect(DateFormatter.formatDating(exhibit), 'details: Late 1800s');
+    });
+
+    test(
+        'formatDating should return "19th Century" for a list item that is not a Map',
+        () {
+      final exhibit = {
+        'production_date': ['19th Century']
+      };
+      expect(DateFormatter.formatDating(exhibit), '19th Century');
+    });
+
+    test('formatDating should return cleaned string for a non-list value', () {
+      final exhibit = {'production_date': 'circa 1850'};
+      expect(DateFormatter.formatDating(exhibit), 'circa 1850');
+    });
+
+    test('formatDating should clean up structural characters in fallback', () {
+      final exhibit = {'production_date': '{period: 1800s}'};
+      expect(DateFormatter.formatDating(exhibit), 'period: 1800s');
+
+      final exhibit2 = {
+        'production_date': '[{"period": "19th Century"}]'
+      }; // String representation of a list
+      expect(DateFormatter.formatDating(exhibit2), '"period": "19th Century"');
+    });
+
+    test('formatDating should handle null exhibit gracefully', () {
+      expect(DateFormatter.formatDating(null), 'Unknown');
+    });
+  });
+}
+
+class ComplexObject {}

--- a/test/utils/dimension_formatter_test.dart
+++ b/test/utils/dimension_formatter_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:indoor_crowded_regions_frontend/utils/dimension_formatter.dart';
+
+void main() {
+  group('DimensionFormatter Tests', () {
+    test(
+        'formatNettoDimensions should return formatted string for all dimensions',
+        () {
+      final exhibit = {
+        'dimensions': [
+          {'part': 'Netto', 'type': 'højde', 'unit': 'centimeter', 'value': '10.5'},
+          {'part': 'Netto', 'type': 'bredde', 'unit': 'centimeter', 'value': '20'},
+          {'part': 'Netto', 'type': 'dybde', 'unit': 'centimeter', 'value': '5.25'},
+          {'part': 'Brutto', 'type': 'højde', 'unit': 'meter', 'value': '1.1'},
+        ]
+      };
+      expect(DimensionFormatter.formatNettoDimensions(exhibit),
+          'Height: 10.5 cm × Width: 20 cm × Depth: 5.3 cm');
+    });
+
+    test('formatNettoDimensions should return formatted string for height only',
+        () {
+      final exhibit = {
+        'dimensions': [
+          {'part': 'Netto', 'type': 'højde', 'unit': 'centimeter', 'value': '150'},
+          {'part': 'Brutto', 'type': 'bredde', 'unit': 'meter', 'value': '2'},
+        ]
+      };
+      expect(DimensionFormatter.formatNettoDimensions(exhibit),
+          'Height: 150 cm');
+    });
+
+    test('formatNettoDimensions should return formatted string for width only',
+        () {
+      final exhibit = {
+        'dimensions': [
+          {'part': 'Netto', 'type': 'bredde', 'unit': 'centimeter', 'value': '75.8'},
+        ]
+      };
+      expect(
+          DimensionFormatter.formatNettoDimensions(exhibit), 'Width: 75.8 cm');
+    });
+
+    test('formatNettoDimensions should return formatted string for depth only',
+        () {
+      final exhibit = {
+        'dimensions': [
+          {'part': 'Netto', 'type': 'dybde', 'unit': 'centimeter', 'value': '30'},
+        ]
+      };
+      expect(DimensionFormatter.formatNettoDimensions(exhibit), 'Depth: 30 cm');
+    });
+
+    test(
+        'formatNettoDimensions should return formatted string for height and width',
+        () {
+      final exhibit = {
+        'dimensions': [
+          {'part': 'Netto', 'type': 'højde', 'unit': 'centimeter', 'value': '100'},
+          {'part': 'Netto', 'type': 'bredde', 'unit': 'centimeter', 'value': '50.1'},
+        ]
+      };
+      expect(DimensionFormatter.formatNettoDimensions(exhibit),
+          'Height: 100 cm × Width: 50.1 cm');
+    });
+
+    test('formatNettoDimensions should return null for empty dimensions list',
+        () {
+      final exhibit = {'dimensions': []};
+      expect(DimensionFormatter.formatNettoDimensions(exhibit), null);
+    });
+
+    test('formatNettoDimensions should return null for null dimensions list',
+        () {
+      final exhibit = {'dimensions': null};
+      expect(DimensionFormatter.formatNettoDimensions(exhibit), null);
+    });
+
+    test(
+        'formatNettoDimensions should return null if no Netto centimeter dimensions are present',
+        () {
+      final exhibit = {
+        'dimensions': [
+          {'part': 'Brutto', 'type': 'højde', 'unit': 'centimeter', 'value': '100'},
+          {'part': 'Netto', 'type': 'bredde', 'unit': 'meter', 'value': '0.5'},
+        ]
+      };
+      expect(DimensionFormatter.formatNettoDimensions(exhibit), null);
+    });
+
+    test('formatNettoDimensions should ignore dimensions with missing keys',
+        () {
+      final exhibit = {
+        'dimensions': [
+          {'part': 'Netto', 'type': 'højde', 'unit': 'centimeter', 'value': '100'},
+          {'part': 'Netto', 'type': 'bredde', 'unit': 'centimeter'}, // Missing value
+          {'part': 'Netto', 'type': 'dybde', 'value': '10'}, // Missing unit
+          {'part': 'Netto', 'unit': 'centimeter', 'value': '20'}, // Missing type
+          {'type': 'højde', 'unit': 'centimeter', 'value': '5'}, // Missing part
+        ]
+      };
+      expect(DimensionFormatter.formatNettoDimensions(exhibit),
+          'Height: 100 cm');
+    });
+
+    test(
+        'formatNettoDimensions should ignore dimensions with non-numeric value',
+        () {
+      final exhibit = {
+        'dimensions': [
+          {'part': 'Netto', 'type': 'højde', 'unit': 'centimeter', 'value': '100'},
+          {'part': 'Netto', 'type': 'bredde', 'unit': 'centimeter', 'value': 'abc'}, // Non-numeric
+        ]
+      };
+      expect(DimensionFormatter.formatNettoDimensions(exhibit),
+          'Height: 100 cm');
+    });
+  });
+}
+
+// Helper class to simulate a complex object that might cause an error
+class ComplexObject {}


### PR DESCRIPTION
This pull request introduces significant improvements to the UI components of the application, focusing on enhancing the user experience, particularly in dark mode, and adding new features for better exhibit representation. Key changes include the addition of new widgets for detailed exhibit views, styling updates, and improved interactivity.

### Enhancements to Artwork Display and Interaction:
* **`ArtworkResultsList` (`lib/ui/components/artwork_result_list.dart`)**: Updated to use a new `ExhibitCard` widget for a more visually appealing and consistent display of artworks. Added a `_showExhibitDetails` method to open a detailed dialog for each exhibit. Improved "No results found" message styling for dark mode. [[1]](diffhunk://#diff-0d1b6dbcd9a281c0f9e2d62bb32d8caebee87fcd42fc4734a1e42ebc6fd3eea9R2-R4) [[2]](diffhunk://#diff-0d1b6dbcd9a281c0f9e2d62bb32d8caebee87fcd42fc4734a1e42ebc6fd3eea9L17-R34) [[3]](diffhunk://#diff-0d1b6dbcd9a281c0f9e2d62bb32d8caebee87fcd42fc4734a1e42ebc6fd3eea9L35-R54) [[4]](diffhunk://#diff-0d1b6dbcd9a281c0f9e2d62bb32d8caebee87fcd42fc4734a1e42ebc6fd3eea9L52-R96)
* **`ExhibitCard` (`lib/ui/components/exhibit_card.dart`)**: Introduced a new widget to display exhibit information in a card format, with support for images, artist names, titles, and locations. Added visual cues like a gradient overlay and link indicators for exhibits with external links.

### New Dialog for Exhibit Details:
* **`ExhibitDetailDialog` (`lib/ui/components/exhibit_detail_dialog.dart`)**: Added a dialog to show detailed information about an exhibit, including materials, techniques, dimensions, colors, and a description. Includes a "View on Website" button for exhibits with external links.

### Additional Supporting Widgets:
* **`ColorSection` (`lib/ui/components/color_section.dart`)**: Added a widget to display color information for exhibits, with color chips and names styled for dark mode.
* **`ExhibitDetailRow` (`lib/ui/components/exhibit_detail_row.dart`)**: Added a reusable widget to display labeled rows of information in the exhibit detail dialog.

### Dark Mode Styling Improvements:
* **`SearchInputBar` (`lib/ui/components/search_input_bar.dart`)**: Updated the search bar with a dark background, brighter orange icons, and lighter text for better visibility in dark mode.