### PR TITLE
Burger buttons highlight 🍔 ⏹️ 👠 

### DIFF
--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -364,7 +364,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     });
   }
 
-  void _simulateMapTap(PolygonArea polygon) {
+  void simulateMapTap(PolygonArea polygon) {
     if (polygon.points.isEmpty) return;
     final center = _calculatePolygonCenter(polygon.points);
     _handleMapTap(const TapPosition(Offset(0, 0), Offset(0, 0)), center);
@@ -374,6 +374,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       _selectingFromRoom = false;
       _selectingToRoom = false;
     });
+    print("simulating maptap...");
   }
 
   @override
@@ -409,6 +410,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 fromRoom: _fromRoom,
                 toRoom: _toRoom,
                 highlightedCategory: highlightedCategory,
+                simulateMapTap: simulateMapTap,
               );
             },
           ),

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -215,7 +215,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       setState(() {
         if (tappedPolygon?.type == highlightedCategory) {
           highlightedCategory = "";
-          print("category sert to empty");
         }
         _fromRoom = Room(
           id: tappedPolygon?.id,
@@ -232,7 +231,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       setState(() {
         if (tappedPolygon?.type == highlightedCategory) {
           highlightedCategory = "";
-          print("category sert to empty");
         }
         _toRoom = Room(
           id: tappedPolygon?.id,
@@ -373,8 +371,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       _showInfoPanel = true;
       _selectingFromRoom = false;
       _selectingToRoom = false;
+      highlightedCategory = '';
     });
-    print("simulating maptap...");
   }
 
   @override

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -167,6 +167,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       _selectedPolygon = null;
       _showInfoPanel = false;
     });
+    
     Navigator.pop(context);
   }
 
@@ -212,6 +213,10 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
     if (_selectingFromRoom) {
       setState(() {
+        if (tappedPolygon?.type == highlightedCategory) {
+          highlightedCategory = "";
+          print("category sert to empty");
+        }
         _fromRoom = Room(
           id: tappedPolygon?.id,
           name: tappedPolygon?.name ?? "Unknown Room",
@@ -225,6 +230,10 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
     if (_selectingToRoom) {
       setState(() {
+        if (tappedPolygon?.type == highlightedCategory) {
+          highlightedCategory = "";
+          print("category sert to empty");
+        }
         _toRoom = Room(
           id: tappedPolygon?.id,
           name: tappedPolygon?.name ?? "Unknown Room",
@@ -350,6 +359,18 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
   void _cancelSelection() {
     setState(() {
+      _selectingFromRoom = false;
+      _selectingToRoom = false;
+    });
+  }
+
+  void _simulateMapTap(PolygonArea polygon) {
+    if (polygon.points.isEmpty) return;
+    final center = _calculatePolygonCenter(polygon.points);
+    _handleMapTap(const TapPosition(Offset(0, 0), Offset(0, 0)), center);
+    setState(() {
+      _selectedPolygon = polygon;
+      _showInfoPanel = true;
       _selectingFromRoom = false;
       _selectingToRoom = false;
     });

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -387,6 +387,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 onPositionChanged: _handlePositionChanged,
                 fromRoom: _fromRoom,
                 toRoom: _toRoom,
+                highlightedCategory: highlightedCategory,
               );
             },
           ),

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -164,6 +164,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   void highlightRooms(String category) {
     setState(() {
       highlightedCategory = (highlightedCategory == category) ? "" : category;
+      _currentFloor = 1;
       _selectedPolygon = null;
       _showInfoPanel = false;
     });

--- a/lib/ui/widgets/burger_drawer.dart
+++ b/lib/ui/widgets/burger_drawer.dart
@@ -37,17 +37,17 @@ class BurgerDrawerState extends State<BurgerDrawer> {
                   ListTile(
                     leading: const Icon(Icons.wc_rounded),
                     title: const Text('Bathrooms'),
-                    onTap: () => highlightedCategory("Bathroom"),
+                    onTap: () => highlightedCategory("BATHROOM"),
                   ),
                   ListTile(
                     leading: const Icon(Icons.shopping_cart_outlined),
                     title: const Text('Shops'),
-                    onTap: () => ErrorToast.show('Shop is currently not available.'),
+                    onTap: () => highlightedCategory("SHOP"),
                   ),
                   ListTile(
                     leading: const Icon(Icons.food_bank_outlined),
                     title: const Text('Food'),
-                    onTap: () => highlightedCategory("Cafeteria"),
+                    onTap: () => highlightedCategory("FOOD"),
                   ),
                   ListTile(
                     leading: const Icon(Icons.location_on_outlined),

--- a/lib/ui/widgets/map/map_widget.dart
+++ b/lib/ui/widgets/map/map_widget.dart
@@ -22,6 +22,7 @@ class MapWidget extends StatefulWidget {
   final Room? fromRoom;
   final Room? toRoom;
   final String highlightedCategory;
+  final Function(PolygonArea) simulateMapTap;
 
   const MapWidget({
     super.key,
@@ -39,6 +40,7 @@ class MapWidget extends StatefulWidget {
     this.fromRoom,
     this.toRoom,
     required this.highlightedCategory,
+    required this.simulateMapTap
   });
 
   @override
@@ -57,7 +59,19 @@ class _MapWidgetState extends State<MapWidget> {
         .where((polygon) =>
             polygon.additionalData?['floor'] == widget.currentFloor)
         .toList();
-
+    final typeCounts = <String, int>{};
+    for (final polygon in floorPolygons) {
+      typeCounts[polygon.type] = (typeCounts[polygon.type] ?? 0) + 1;
+      print('Polygon Type: ${polygon.type}, Count: ${typeCounts[polygon.type]}');
+    }
+    if (typeCounts[widget.highlightedCategory] == 1) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final polygon = floorPolygons.firstWhere(
+          (polygon) => polygon.type == widget.highlightedCategory,
+        );
+        widget.simulateMapTap(polygon);
+      });
+    }
     // Find the polygon objects for fromRoom and toRoom
     PolygonArea? fromRoomPolygon;
     PolygonArea? toRoomPolygon;
@@ -102,7 +116,6 @@ class _MapWidgetState extends State<MapWidget> {
         ),
         Stack(
           children: [
-            // Regular polygons
             PolygonLayer(
               polygons: floorPolygons
                   .where((polygon) =>
@@ -110,18 +123,17 @@ class _MapWidgetState extends State<MapWidget> {
                       polygon.id != widget.selectedPolygon!.id)
                   .map((polygon) {
                 return Polygon(
-                  points: polygon.points,
-                  color: widget.isSelectingOnMap || polygon.type == widget.highlightedCategory
+                  points: polygon.points, 
+                  color: widget.isSelectingOnMap || (polygon.type == widget.highlightedCategory && typeCounts[polygon.type]! > 1)
                       ? Colors.blue.withValues(alpha: 0.15)
                       : Colors.white.withValues(alpha: 0.15),
-                  borderColor: widget.isSelectingOnMap || polygon.type == widget.highlightedCategory
+                  borderColor: widget.isSelectingOnMap || (polygon.type == widget.highlightedCategory && typeCounts[polygon.type]! > 1)
                       ? Colors.blueAccent.withValues(alpha: 0.8)
                       : Colors.white.withValues(alpha: 0.6),
-                  borderStrokeWidth: widget.isSelectingOnMap || polygon.type == widget.highlightedCategory? 2.0 : 1.0,
+                  borderStrokeWidth: widget.isSelectingOnMap || (polygon.type == widget.highlightedCategory && typeCounts[polygon.type]! > 1) ? 2.0 : 1.0,
                 );
               }).toList(),
             ),
-
             // Selected polygon with pulse animation
             if (widget.selectedPolygon != null && !widget.isSelectingOnMap)
               AnimatedBuilder(

--- a/lib/ui/widgets/map/map_widget.dart
+++ b/lib/ui/widgets/map/map_widget.dart
@@ -62,7 +62,6 @@ class _MapWidgetState extends State<MapWidget> {
     final typeCounts = <String, int>{};
     for (final polygon in floorPolygons) {
       typeCounts[polygon.type] = (typeCounts[polygon.type] ?? 0) + 1;
-      print('Polygon Type: ${polygon.type}, Count: ${typeCounts[polygon.type]}');
     }
     if (typeCounts[widget.highlightedCategory] == 1) {
       WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/ui/widgets/map/map_widget.dart
+++ b/lib/ui/widgets/map/map_widget.dart
@@ -111,13 +111,13 @@ class _MapWidgetState extends State<MapWidget> {
                   .map((polygon) {
                 return Polygon(
                   points: polygon.points,
-                  color: widget.isSelectingOnMap
+                  color: widget.isSelectingOnMap || polygon.type == widget.highlightedCategory
                       ? Colors.blue.withValues(alpha: 0.15)
-                      : polygon.type == widget.highlightedCategory ? Colors.orange.withValues(alpha: 0.15) : Colors.white.withValues(alpha: 0.15),
-                  borderColor: widget.isSelectingOnMap
+                      : Colors.white.withValues(alpha: 0.15),
+                  borderColor: widget.isSelectingOnMap || polygon.type == widget.highlightedCategory
                       ? Colors.blueAccent.withValues(alpha: 0.8)
-                      : polygon.type == widget.highlightedCategory ? Colors.orange.withValues(alpha: 0.60) : Colors.white.withValues(alpha: 0.6),
-                  borderStrokeWidth: widget.isSelectingOnMap ? 2.0 : 1.0,
+                      : Colors.white.withValues(alpha: 0.6),
+                  borderStrokeWidth: widget.isSelectingOnMap || polygon.type == widget.highlightedCategory? 2.0 : 1.0,
                 );
               }).toList(),
             ),

--- a/lib/ui/widgets/map/map_widget.dart
+++ b/lib/ui/widgets/map/map_widget.dart
@@ -21,6 +21,7 @@ class MapWidget extends StatefulWidget {
   final Function(MapCamera, bool) onPositionChanged;
   final Room? fromRoom;
   final Room? toRoom;
+  final String highlightedCategory;
 
   const MapWidget({
     super.key,
@@ -37,6 +38,7 @@ class MapWidget extends StatefulWidget {
     required this.onPositionChanged,
     this.fromRoom,
     this.toRoom,
+    required this.highlightedCategory,
   });
 
   @override
@@ -111,10 +113,10 @@ class _MapWidgetState extends State<MapWidget> {
                   points: polygon.points,
                   color: widget.isSelectingOnMap
                       ? Colors.blue.withValues(alpha: 0.15)
-                      : Colors.white.withValues(alpha: 0.15),
+                      : polygon.type == widget.highlightedCategory ? Colors.orange.withValues(alpha: 0.15) : Colors.white.withValues(alpha: 0.15),
                   borderColor: widget.isSelectingOnMap
                       ? Colors.blueAccent.withValues(alpha: 0.8)
-                      : Colors.white.withValues(alpha: 0.6),
+                      : polygon.type == widget.highlightedCategory ? Colors.orange.withValues(alpha: 0.60) : Colors.white.withValues(alpha: 0.6),
                   borderStrokeWidth: widget.isSelectingOnMap ? 2.0 : 1.0,
                 );
               }).toList(),


### PR DESCRIPTION
This pull request introduces enhancements to the map interaction and category highlighting features in the application. The changes focus on improving the user experience when selecting and highlighting specific categories on the map, ensuring better visual feedback and functionality. Key updates include adding support for automatic polygon selection when a single category match exists, refining the visual representation of highlighted polygons, and updating the behavior of the category selection logic.

### Enhancements to category highlighting and map interaction:

* **Automatic polygon selection for single matches**: When a highlighted category has exactly one matching polygon on the current floor, the map automatically simulates a tap on that polygon, selecting it and displaying its information. (`lib/ui/widgets/map/map_widget.dart`, [lib/ui/widgets/map/map_widget.dartL58-R73](diffhunk://#diff-7b0460bd3a8cd4898f0e228e676c9910324ed9be12b8eab0e08425e9e6fa0233L58-R73))

* **Improved polygon highlighting**: Polygons matching the highlighted category are visually distinguished with updated colors and border styles, but only when there are multiple matches. (`lib/ui/widgets/map/map_widget.dart`, [lib/ui/widgets/map/map_widget.dartL112-L122](diffhunk://#diff-7b0460bd3a8cd4898f0e228e676c9910324ed9be12b8eab0e08425e9e6fa0233L112-L122))

* **New `simulateMapTap` method**: Added a method to programmatically simulate a map tap on a polygon, centralizing the logic for selecting and displaying polygon information. (`lib/ui/screens/home_screen.dart`, [lib/ui/screens/home_screen.dartR366-R378](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R366-R378))

### Updates to category selection logic:

* **Reset highlighted category on room selection**: If a room is selected and its type matches the currently highlighted category, the category is reset to avoid conflicts. (`lib/ui/screens/home_screen.dart`, [[1]](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R217-R219) [[2]](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R233-R235)

* **Standardized category strings**: Updated the category strings in the burger drawer to use consistent, uppercase values for better maintainability. (`lib/ui/widgets/burger_drawer.dart`, [lib/ui/widgets/burger_drawer.dartL40-R50](diffhunk://#diff-6194a6829277f015d12605a1fe79109fcce12e249e8ff3d78398632cdedcd7caL40-R50))

***NOTE: when clicking on one of these buttons, it switches to first floor, as the rooms with the burger menu categories all occur on the first floor (at least to our knowledge). This should be altered at some point.***