### PR TITLE
feat: path per floor

### DIFF
--- a/lib/ui/widgets/map/map_widget.dart
+++ b/lib/ui/widgets/map/map_widget.dart
@@ -296,7 +296,13 @@ class _MapWidgetState extends State<MapWidget> {
             }).toList(),
           ),
         if (widget.pathData != null && widget.pathData!.isNotEmpty)
-          LinePath(pathCoordinates: widget.pathData!),
+          if (widget.pathData != null)
+            LinePath(
+              pathCoordinates: widget.pathData!
+                  .where((sensor) => sensor.rooms
+                      .any((room) => room.floor == widget.currentFloor))
+                  .toList(),
+            ),
         if (widget.userLocationWidget != null) widget.userLocationWidget!,
       ],
     );

--- a/lib/ui/widgets/utils/types.dart
+++ b/lib/ui/widgets/utils/types.dart
@@ -5,6 +5,7 @@ class RoomObject {
   final int occupants;
   final double area;
   final double popularityFactor;
+  final int floor;
 
   RoomObject({
     required this.id,
@@ -13,6 +14,7 @@ class RoomObject {
     required this.occupants,
     required this.area,
     required this.popularityFactor,
+    required this.floor,
   });
 
   factory RoomObject.fromJson(Map<String, dynamic> json) {
@@ -23,6 +25,7 @@ class RoomObject {
       occupants: json['occupants'],
       area: (json['area'] as num).toDouble(),
       popularityFactor: (json['popularity_factor'] as num).toDouble(),
+      floor: json['floor'],
     );
   }
 }

--- a/test/home_screen_tests/line_path_test.dart
+++ b/test/home_screen_tests/line_path_test.dart
@@ -33,11 +33,33 @@ void main() {
                 id: "sensor1",
                 longitude: 12.577325,
                 latitude: 55.688495,
+                rooms: [
+                  RoomObject(
+                    id: "room1",
+                    name: "Room 1",
+                    crowdFactor: 0.5,
+                    occupants: 10,
+                    area: 20.0,
+                    popularityFactor: 0.7,
+                    floor: 1,
+                  ),
+                ],
               ),
               DoorObject(
                 id: "sensor2",
                 longitude: 12.577545,
                 latitude: 55.688732,
+                rooms: [
+                  RoomObject(
+                    id: "room2",
+                    name: "Room 2",
+                    crowdFactor: 0.6,
+                    occupants: 15,
+                    area: 25.0,
+                    popularityFactor: 0.8,
+                    floor: 1,
+                  ),
+                ],
               ),
             ]);
 
@@ -65,11 +87,33 @@ void main() {
                 id: "sensor1",
                 longitude: 12.577325,
                 latitude: 55.688495,
+                rooms: [
+                  RoomObject(
+                    id: "room1",
+                    name: "Room 1",
+                    crowdFactor: 0.5,
+                    occupants: 10,
+                    area: 20.0,
+                    popularityFactor: 0.7,
+                    floor: 1,
+                  ),
+                ],
               ),
               DoorObject(
                 id: "sensor2",
                 longitude: 12.577545,
                 latitude: 55.688732,
+                rooms: [
+                  RoomObject(
+                    id: "room2",
+                    name: "Room 2",
+                    crowdFactor: 0.6,
+                    occupants: 15,
+                    area: 25.0,
+                    popularityFactor: 0.8,
+                    floor: 1,
+                  ),
+                ],
               ),
             ]);
 
@@ -98,16 +142,49 @@ void main() {
                 id: "sensor1",
                 longitude: 12.577325,
                 latitude: 55.688495,
+                rooms: [
+                  RoomObject(
+                    id: "room1",
+                    name: "Room 1",
+                    crowdFactor: 0.5,
+                    occupants: 10,
+                    area: 20.0,
+                    popularityFactor: 0.7,
+                    floor: 1,
+                  ),
+                ],
               ),
               DoorObject(
                 id: "sensor2",
                 longitude: 12.577545,
                 latitude: 55.688732,
+                rooms: [
+                  RoomObject(
+                    id: "room2",
+                    name: "Room 2",
+                    crowdFactor: 0.6,
+                    occupants: 15,
+                    area: 25.0,
+                    popularityFactor: 0.8,
+                    floor: 1,
+                  ),
+                ],
               ),
               DoorObject(
                 id: "sensor3",
                 longitude: 12.577640,
                 latitude: 55.688732,
+                rooms: [
+                  RoomObject(
+                    id: "room3",
+                    name: "Room 3",
+                    crowdFactor: 0.5,
+                    occupants: 10,
+                    area: 20.0,
+                    popularityFactor: 0.7,
+                    floor: 1,
+                  ),
+                ],
               ),
             ]);
 

--- a/test/path_tests/path_test.dart
+++ b/test/path_tests/path_test.dart
@@ -11,6 +11,7 @@ void main() {
       occupants: 5,
       area: 25.0,
       popularityFactor: 0.6,
+      floor: 1,
     );
 
     final roomB = RoomObject(
@@ -20,6 +21,7 @@ void main() {
       occupants: 15,
       area: 30.0,
       popularityFactor: 0.9,
+      floor: 1,
     );
 
     final initPath = [

--- a/test/path_tests/test_path.dart
+++ b/test/path_tests/test_path.dart
@@ -11,6 +11,7 @@ void mainTest() {
       occupants: 5,
       area: 25.0,
       popularityFactor: 0.6,
+      floor: 1,
     );
 
     final roomB = RoomObject(
@@ -20,6 +21,7 @@ void mainTest() {
       occupants: 15,
       area: 30.0,
       popularityFactor: 0.9,
+      floor: 1,
     );
 
     final initPath = [


### PR DESCRIPTION
This pull request introduces functionality to filter map path data by the current floor and updates the `RoomObject` class to include a `floor` property. These changes improve the accuracy of path rendering on the map widget and enhance data modeling for room objects.

### Map Path Filtering:

* [`lib/ui/widgets/map/map_widget.dart`](diffhunk://#diff-7b0460bd3a8cd4898f0e228e676c9910324ed9be12b8eab0e08425e9e6fa0233L299-R305): Updated the `LinePath` widget to filter `pathCoordinates` by the `floor` property of rooms, ensuring that only paths relevant to the `currentFloor` are displayed.

### RoomObject Enhancements:

* [`lib/ui/widgets/utils/types.dart`](diffhunk://#diff-e3d11c5dc7823b4dc8968fbd183e87185d911a60d762348d834f4761ef2e100fR8): Added a new `floor` property to the `RoomObject` class to represent the floor number of a room. This property is now required in the constructor and included in the JSON deserialization logic. [[1]](diffhunk://#diff-e3d11c5dc7823b4dc8968fbd183e87185d911a60d762348d834f4761ef2e100fR8) [[2]](diffhunk://#diff-e3d11c5dc7823b4dc8968fbd183e87185d911a60d762348d834f4761ef2e100fR17) [[3]](diffhunk://#diff-e3d11c5dc7823b4dc8968fbd183e87185d911a60d762348d834f4761ef2e100fR28)