### PR TITLE
feat: refresh rooms periodically

### DIFF
--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart'; // Contains MapController, MapPosition, MapEvent classes
 import 'package:latlong2/latlong.dart';
@@ -59,6 +61,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   UserLocationWidget? userLocationWidget;
   double _currentZoom = 18.0;
   int _currentFloor = 1;
+  late Timer _refreshTimer;
 
   late Future<List<PolygonArea>> _polygonsFuture = Future.value([]);
   late List<PolygonArea> _polygons = [];
@@ -95,6 +98,12 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       ),
     );
 
+    _refreshTimer = Timer.periodic(const Duration(seconds: 30), (timer) {
+      if (mounted) {
+        _loadPolygons(_currentFloor);
+      }
+    });
+
     if (widget.isTestMode) {
       _pulseAnimationController.value = 0.85;
     } else {
@@ -119,6 +128,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   void dispose() {
     _pulseAnimationController.dispose();
     mapController.dispose();
+    _refreshTimer.cancel();
     super.dispose();
   }
 
@@ -355,6 +365,12 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       _currentFloor = floor;
     });
     _loadPolygons(floor);
+    _refreshTimer.cancel();
+    _refreshTimer = Timer.periodic(const Duration(seconds: 30), (timer) {
+      if (mounted) {
+        _loadPolygons(floor);
+      }
+    });
   }
 
   void _cancelSelection() {


### PR DESCRIPTION
This pull request introduces a periodic refresh mechanism for loading polygons on the `HomeScreen` and ensures proper cleanup of the associated timer. The most important changes include adding a `Timer` to refresh polygons every 30 seconds, integrating the timer into the lifecycle of the `HomeScreen`, and ensuring it is properly disposed of to prevent memory leaks.

### Periodic refresh mechanism:

* [`lib/ui/screens/home_screen.dart`](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R101-R106): Introduced a `_refreshTimer` to periodically refresh polygons every 30 seconds by calling `_loadPolygons` with the current floor. This is initialized in the `initState` equivalent and updated when the floor changes. [[1]](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R101-R106) [[2]](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R368-R373)

### Lifecycle management:

* [`lib/ui/screens/home_screen.dart`](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R131): Ensured `_refreshTimer` is properly canceled in the `dispose` method to prevent memory leaks.

### Code additions:

* [`lib/ui/screens/home_screen.dart`](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R1-R2): Added `dart:async` import to enable the use of `Timer`.