### PR TITLE
test: reworked tests for beautifyPath

### DIFF
--- a/test/path_tests/path_test.dart
+++ b/test/path_tests/path_test.dart
@@ -2,56 +2,109 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:indoor_crowded_regions_frontend/ui/widgets/utils/path_beautify.dart';
 import 'package:indoor_crowded_regions_frontend/ui/widgets/utils/types.dart';
 
+
+List<DoorObject> createInitRoute(List<(double, double, bool)> coordinates) {
+  RoomObject room = RoomObject(
+    id: 'room1',
+    name: 'Room 1',
+    crowdFactor: 0.5,
+    occupants: 10,
+    area: 20.0,
+    popularityFactor: 0.7,
+    floor: 1,
+  );
+
+  return coordinates
+      .map((coord) => DoorObject(
+            latitude: coord.$1,
+            longitude: coord.$2,
+            isVertical: coord.$3,
+            rooms: [room],
+          ))
+      .toList();
+}
 void main() {
-  test('beautifyPath adds intermediate points correctly', () {
-    final roomA = RoomObject(
-      id: 'A',
-      name: 'Room A',
-      crowdFactor: 0.3,
-      occupants: 5,
-      area: 25.0,
-      popularityFactor: 0.6,
-      floor: 1,
-    );
-
-    final roomB = RoomObject(
-      id: 'B',
-      name: 'Room B',
-      crowdFactor: 0.7,
-      occupants: 15,
-      area: 30.0,
-      popularityFactor: 0.9,
-      floor: 1,
-    );
-
-    final initPath = [
-      DoorObject(
-        id: 'D1',
-        latitude: 40.0,
-        longitude: -74.0,
-        isVertical: true,
-        rooms: [roomA],
-      ),
-      DoorObject(
-        id: 'D2',
-        latitude: 40.0001,
-        longitude: -74.0,
-        isVertical: true,
-        rooms: [roomA, roomB],
-      ),
-      DoorObject(
-        id: 'D3',
-        latitude: 40.0001,
-        longitude: -73.9999,
-        isVertical: false,
-        rooms: [roomB],
-      ),
-    ];
+  test('beautifyPath adds intermediate points correctly (opposite)', () {
+    final List<DoorObject> initPath = createInitRoute([
+      (40.0, -74.0, true),
+      (40.5, -76.0, true),
+    ]);
 
     final result = beautifyPath(initPath);
 
-    expect(result.length, greaterThan(initPath.length)); // Should add intermediate points
-    expect(result.first.latitude, equals(40.0));
-    expect(result.last.longitude, equals(-73.9999));
+    final expectedPathCoords = [
+      (40.0, -74.0),
+      (40.0, -75.0),
+      (40.5, -75.0),
+      (40.5, -76.0),
+    ];
+
+    expect(result.length, equals(4)); // Should add two intermediate points
+
+    for (int i = 0; i < result.length; i++) {
+      expect(result[i].latitude, equals(expectedPathCoords[i].$1),
+          reason:
+              "Latitude mismatch at index $i: expected ${expectedPathCoords[i].$1}, got ${result[i].latitude}");
+      expect(result[i].longitude, equals(expectedPathCoords[i].$2),
+          reason:
+              "Longitude mismatch at index $i: expected ${expectedPathCoords[i].$2}, got ${result[i].longitude}");
+    }
+  });
+
+  test('beautifyPath handles empty path', () {
+    final result = beautifyPath([]);
+    expect(result, isEmpty);
+  });
+
+  test('beautifyPath adds intermediate points correctly (perpendicular)', () {
+    final List<DoorObject> initPath = createInitRoute([
+      (40.0, -74.0, false),
+      (45.0, -71.0, true),
+    ]);
+
+    final result = beautifyPath(initPath);
+
+    final expectedPathCoords = [
+      (40.0, -74.0),
+      (45.0, -74.0),
+      (45.0, -71.0),
+    ];
+
+    expect(result.length, equals(3)); // Should add two intermediate points
+    for (int i = 0; i < result.length; i++) {
+      expect(result[i].latitude, equals(expectedPathCoords[i].$1),
+          reason:
+              "Latitude mismatch at index $i: expected ${expectedPathCoords[i].$1}, got ${result[i].latitude}");
+      expect(result[i].longitude, equals(expectedPathCoords[i].$2),
+          reason:
+              "Longitude mismatch at index $i: expected ${expectedPathCoords[i].$2}, got ${result[i].longitude}");
+    }
+  });
+
+  test('beautifyPath adds intermediate points correctly (same)', () {
+    final List<DoorObject> initPath = createInitRoute([
+      (40.0, -74.0, true),
+      (45.0, -74.0, true),
+    ]);
+
+    final result = beautifyPath(initPath);
+
+    final expectedPathCoords = [
+      (40.0, -74.0),
+      (40.0, -73.99995),
+      (45.0, -73.99995),
+      (45.0, -74.0),
+    ];
+
+    expect(result.length, equals(4)); // Should add two intermediate points
+
+    for(int i = 0; i < result.length; i++) {
+      expect(result[i].latitude, equals(expectedPathCoords[i].$1),
+          reason:
+              "Latitude mismatch at index $i: expected ${expectedPathCoords[i].$1}, got ${result[i].latitude}");
+      expect(result[i].longitude, equals(expectedPathCoords[i].$2),
+          reason:
+              "Longitude mismatch at index $i: expected ${expectedPathCoords[i].$2}, got ${result[i].longitude}");
+    }
   });
 }


### PR DESCRIPTION
This pull request refactors and enhances the test suite for the `beautifyPath` function in `path_test.dart`. The main changes include the introduction of a helper method to streamline test setup, the addition of new test cases to cover more scenarios, and improved assertions for better clarity in test failures.

### Test Suite Refactor and Enhancements:

* **Refactored test setup with `createInitRoute` helper method**: Added a utility function `createInitRoute` to generate initial paths dynamically, reducing redundancy and improving test readability.

* **Expanded test coverage for `beautifyPath`**:
  - Added a test for handling empty paths to ensure the function returns an empty result.
  - Introduced new test cases for specific scenarios:
    - Opposite-direction intermediate points.
    - Perpendicular intermediate points.
    - Same-direction intermediate points.

* **Improved test assertions**: Enhanced the assertions to include detailed error messages for mismatched latitude and longitude values, aiding in debugging test failures.