### PR TITLE
feat: Added credits and fixed bug with closing menus on update

### DIFF
--- a/lib/ui/components/exhibit_card.dart
+++ b/lib/ui/components/exhibit_card.dart
@@ -138,6 +138,18 @@ class ExhibitCard extends StatelessWidget {
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4.0),
+                    child: Text(
+                      "Source: Statens Museums for Kunst, open.smk.dk",
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Colors.grey.shade400, // Lighter gray for visibility
+                        fontStyle: FontStyle.italic,
+                      ),
+                    ),
+                  )
+
               ],
             ),
           ),

--- a/lib/ui/components/exhibit_detail_dialog.dart
+++ b/lib/ui/components/exhibit_detail_dialog.dart
@@ -78,6 +78,9 @@ class ExhibitDetailDialog extends StatelessWidget {
                         ColorSection(label: "Colors", colors: colors),
                       if (description.isNotEmpty && description != "Unknown")
                         _buildDescriptionSection(description),
+                      const ExhibitDetailRow(
+                          label: "Source",
+                          value: "Statens Museums for Kunst, open.smk.dk"),
                       if (frontendUrl != null) _buildLinkButton(frontendUrl),
                     ],
                   ),

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -56,6 +56,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   final APIService apiService = APIService();
   final PolygonService polygonService = PolygonService();
   final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+  final ValueNotifier<List<PolygonArea>> _polygonNotifier =
+      ValueNotifier<List<PolygonArea>>([]);
   final GlobalKey<UserLocationWidgetState> userLocationKey =
       GlobalKey<UserLocationWidgetState>();
 
@@ -65,7 +67,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   int _currentFloor = 1;
   late Timer _refreshTimer;
 
-  late Future<List<PolygonArea>> _polygonsFuture = Future.value([]);
   late List<PolygonArea> _polygons = [];
   PolygonArea? _selectedPolygon;
   bool _showInfoPanel = false;
@@ -100,7 +101,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       ),
     );
 
-    _refreshTimer = Timer.periodic(const Duration(seconds: polygonRefreshInterval), (timer) {
+    _refreshTimer = Timer.periodic(
+        const Duration(seconds: polygonRefreshInterval), (timer) {
       if (mounted) {
         _loadPolygons(_currentFloor);
       }
@@ -131,6 +133,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     _pulseAnimationController.dispose();
     mapController.dispose();
     _refreshTimer.cancel();
+    _polygonNotifier.dispose();
     super.dispose();
   }
 
@@ -140,27 +143,18 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   }
 
   void _loadPolygons(int floor) {
-    setState(() {
-      _polygonsFuture = polygonService.getPolygons(floor: floor);
-      _selectedPolygon = null;
-      _showInfoPanel = false;
-    });
-
-    _polygonsFuture.then((data) {
+    polygonService.getPolygons(floor: floor).then((data) {
       if (mounted) {
-        setState(() {
-          _polygons = data;
-        });
+        print("Loaded ${data.length} polygons for floor $floor");
+        _polygonNotifier.value = data; // notify listeners
       }
     }).catchError((error) {
       if (mounted) {
-        setState(() {
-          _polygons = [];
-        });
+        _polygonNotifier.value = []; // notify with empty list
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Error loading map data for floor $floor.'),
-            backgroundColor: Colors.red.shade700, // Darker red for dark mode
+            backgroundColor: Colors.red.shade700,
           ),
         );
       }
@@ -204,9 +198,9 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   }
 
   void _handleMapTap(TapPosition tapPosition, LatLng point) {
-    final floorPolygons = _polygons
-        .where((p) => p.additionalData?['floor'] == _currentFloor)
-        .toList();
+    final floorPolygons = _polygonNotifier.value
+    .where((p) => p.additionalData?['floor'] == _currentFloor)
+    .toList();
 
     PolygonArea? tappedPolygon;
     for (var polygon in floorPolygons) {
@@ -368,7 +362,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     });
     _loadPolygons(floor);
     _refreshTimer.cancel();
-    _refreshTimer = Timer.periodic(const Duration(seconds: polygonRefreshInterval), (timer) {
+    _refreshTimer = Timer.periodic(
+        const Duration(seconds: polygonRefreshInterval), (timer) {
       if (mounted) {
         _loadPolygons(floor);
       }
@@ -425,25 +420,30 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
           FutureBuilder<List<DoorObject>>(
             future: _edgesFuture,
             builder: (context, snapshot) {
-              return MapWidget(
-                mapController: mapController,
-                currentFloor: _currentFloor,
-                polygons: _polygons,
-                selectedPolygon: _selectedPolygon,
-                pulseAnimation: _pulseAnimation,
-                isSelectingOnMap: isSelectingOnMap,
-                onTap: _handleMapTap,
-                pathData: snapshot.hasData && snapshot.data!.isNotEmpty
-                    ? snapshot.data
-                    : null,
-                userLocationWidget: userLocationWidget,
-                onMapEvent: _handleMapEvent,
-                onPositionChanged: _handlePositionChanged,
-                fromRoom: _fromRoom,
-                toRoom: _toRoom,
-                highlightedCategory: highlightedCategory,
-                simulateMapTap: simulateMapTap,
-              );
+              return ValueListenableBuilder(
+                  valueListenable: _polygonNotifier,
+                  builder: (context, polygons, _) {
+                    print("Building MapWidget with ${polygons.length} polygons");
+                    return MapWidget(
+                      mapController: mapController,
+                      currentFloor: _currentFloor,
+                      polygons: polygons,
+                      selectedPolygon: _selectedPolygon,
+                      pulseAnimation: _pulseAnimation,
+                      isSelectingOnMap: isSelectingOnMap,
+                      onTap: _handleMapTap,
+                      pathData: snapshot.hasData && snapshot.data!.isNotEmpty
+                          ? snapshot.data
+                          : null,
+                      userLocationWidget: userLocationWidget,
+                      onMapEvent: _handleMapEvent,
+                      onPositionChanged: _handlePositionChanged,
+                      fromRoom: _fromRoom,
+                      toRoom: _toRoom,
+                      highlightedCategory: highlightedCategory,
+                      simulateMapTap: simulateMapTap,
+                    );
+                  });
             },
           ),
           Positioned(

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -67,7 +67,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   int _currentFloor = 1;
   late Timer _refreshTimer;
 
-  late List<PolygonArea> _polygons = [];
   PolygonArea? _selectedPolygon;
   bool _showInfoPanel = false;
 
@@ -145,7 +144,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   void _loadPolygons(int floor) {
     polygonService.getPolygons(floor: floor).then((data) {
       if (mounted) {
-        print("Loaded ${data.length} polygons for floor $floor");
         _polygonNotifier.value = data; // notify listeners
       }
     }).catchError((error) {
@@ -423,7 +421,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
               return ValueListenableBuilder(
                   valueListenable: _polygonNotifier,
                   builder: (context, polygons, _) {
-                    print("Building MapWidget with ${polygons.length} polygons");
                     return MapWidget(
                       mapController: mapController,
                       currentFloor: _currentFloor,


### PR DESCRIPTION
This pull request introduces enhancements to the UI components and optimizes the state management for polygons in the `HomeScreen`. The most significant changes include adding source attribution in exhibit-related components and replacing the `Future`-based state management for polygons with a `ValueNotifier` for better reactivity and performance.

### UI Enhancements:
* Added a source attribution text ("Source: Statens Museums for Kunst, open.smk.dk") to the `ExhibitCard` component for improved transparency. (`lib/ui/components/exhibit_card.dart`, [lib/ui/components/exhibit_card.dartR141-R152](diffhunk://#diff-059b8e934d3500b1c007e0c092bd8e3ac484e7b1e95cca2aa7bc86129f274962R141-R152))
* Included a source row in the `ExhibitDetailDialog` component to display the data source consistently. (`lib/ui/components/exhibit_detail_dialog.dart`, [lib/ui/components/exhibit_detail_dialog.dartR81-R83](diffhunk://#diff-fdcef90579bf8a85220817c1bd277b0eef1200cd6b7ad2abe01fb4e1fddfcd7aR81-R83))

### State Management Optimization:
* Replaced the `Future`-based state management for polygons with a `ValueNotifier`, improving reactivity and simplifying updates to the `MapWidget`. (`lib/ui/screens/home_screen.dart`, [[1]](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R59-R60) [[2]](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2L143-R155)
* Updated `_loadPolygons` to directly update the `ValueNotifier` instead of relying on `setState`, reducing unnecessary UI rebuilds. (`lib/ui/screens/home_screen.dart`, [lib/ui/screens/home_screen.dartL143-R155](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2L143-R155))
* Integrated `ValueListenableBuilder` in the `FutureBuilder` to listen for polygon updates and pass them to the `MapWidget`. (`lib/ui/screens/home_screen.dart`, [lib/ui/screens/home_screen.dartR421-R427](diffhunk://#diff-6726dd41354d247f98724fb7ae2c91a99f40c6ca9f72a2cad7af703dec3723f2R421-R427))